### PR TITLE
Adds a command to download Cake bootstrapper

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,4 @@
 *.vsix
+out
+node_modules
+.vscode-test

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,28 @@
+// A launch configuration that compiles the extension and then opens it inside a new window
+{
+	"version": "0.1.0",
+	"configurations": [
+		{
+			"name": "Launch Extension",
+			"type": "extensionHost",
+			"request": "launch",
+			"runtimeExecutable": "${execPath}",
+			"args": ["--extensionDevelopmentPath=${workspaceRoot}" ],
+			"stopOnEntry": false,
+			"sourceMaps": true,
+			"outDir": "${workspaceRoot}/out/src",
+			"preLaunchTask": "npm"
+		},
+		{
+			"name": "Launch Tests",
+			"type": "extensionHost",
+			"request": "launch",
+			"runtimeExecutable": "${execPath}",
+			"args": ["--extensionDevelopmentPath=${workspaceRoot}", "--extensionTestsPath=${workspaceRoot}/out/test" ],
+			"stopOnEntry": false,
+			"sourceMaps": true,
+			"outDir": "${workspaceRoot}/out/test",
+			"preLaunchTask": "npm"
+		}
+	]
+}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,12 @@
+// Place your settings in this file to overwrite default and user settings.
+{
+	"files.exclude": {
+		"out": false, // set this to true to hide the "out" folder with the compiled JS files
+		"typings": false
+	},
+	"search.exclude": {
+		"**/node_modules": true,
+		"out/": true
+	},
+	"typescript.tsdk": "./node_modules/typescript/lib" 
+}

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -1,0 +1,30 @@
+// Available variables which can be used inside of strings.
+// ${workspaceRoot}: the root folder of the team
+// ${file}: the current opened file
+// ${fileBasename}: the current opened file's basename
+// ${fileDirname}: the current opened file's dirname
+// ${fileExtname}: the current opened file's extension
+// ${cwd}: the current working directory of the spawned process
+
+// A task runner that calls a custom npm script that compiles the extension.
+{
+	"version": "0.1.0",
+
+	// we want to run npm
+	"command": "npm",
+
+	// the command is a shell script
+	"isShellCommand": true,
+
+	// show the output window only if unrecognized errors occur.
+	"showOutput": "silent",
+
+	// we run the custom script "compile" as defined in package.json
+	"args": ["run", "compile", "--loglevel", "silent"],
+
+	// The tsc compiler is started in watching mode
+	"isWatching": true,
+
+	// use the standard tsc in watch mode problem matcher to find compile problems in the output.
+	"problemMatcher": "$tsc-watch"
+}

--- a/.vscodeignore
+++ b/.vscodeignore
@@ -1,0 +1,8 @@
+.vscode/**
+typings/**
+out/test/**
+test/**
+**/*.ts
+**/*.map
+.gitignore
+tsconfig.json

--- a/README.md
+++ b/README.md
@@ -2,6 +2,12 @@
 
 This addin brings language support for [Cake](http://cakebuild.net) build scripts to Visual Studio Code.
 
+### Commands
+
+In addition to integrated editing features, the extension also provide a command in the Command Palette for working with Cake files:
+
+* `Cake: Install the bootstrapper` to install the Cake bootstrapper in the root folder.
+
 ## What is Cake?
 
 Cake (C# Make) is a cross platform build automation system with a C# DSL to do things like compiling code, copy files/folders, running unit tests, compress files and build NuGet packages.

--- a/package.json
+++ b/package.json
@@ -22,12 +22,16 @@
         "theme": "light"
   },
 	"engines": {
-		"vscode": "^0.10.1"
+		"vscode": "^0.10.9"
 	},
 	"categories": [
 		"Languages",
 		"Snippets"
 	],
+    "activationEvents": [
+		"onCommand:cake.bootstrapper"
+	],
+    "main": "./out/src/cakeExtension",
 	"contributes": {
 		"languages": [{
 			"id": "cake",
@@ -45,6 +49,25 @@
                 "language": "cake",
                 "path": "./snippets/snippets.json"
             }
-        ]
+        ],
+        "commands": [{
+			"command": "cake.bootstrapper",
+			"title": "Cake: Install the bootstrapper"
+		}],
+		"outputChannels": [
+			"Cake"
+		]
+	},
+    "scripts": {
+		"vscode:prepublish": "node ./node_modules/vscode/bin/compile",
+		"compile": "node ./node_modules/vscode/bin/compile -watch -p ./",
+        "postinstall": "node ./node_modules/vscode/bin/install"
+	},
+    "dependencies": {
+        "request":"^2.67.0"
+    },
+    "devDependencies": {
+		"typescript": "^1.7.5",
+		"vscode": "^0.11.0"
 	}
 }

--- a/src/bootstrapper.ts
+++ b/src/bootstrapper.ts
@@ -1,0 +1,51 @@
+'use strict';
+//import * as request from 'request';
+var request = require('request');
+
+export class Bootstrapper {
+    private baseUrl : string = 'http://cakebuild.net/bootstrapper/';
+    private static supportedPlatforms = {'win32':'Windows','darwin':'OSX','linux':'Linux'};
+    private _buildFilename : string;
+    
+    constructor(private platformName : string) {
+        this._buildFilename = 'build.' + ( (/^win/i.test(platformName)) ? 'ps1' : 'sh' );
+    }
+    
+    public static getPlatformOptions(platform : string) : string[] {
+        
+        let orderedPlatforms =[];
+        
+        let currentPlatformName = Bootstrapper.supportedPlatforms[platform];
+        if (currentPlatformName != null)
+            orderedPlatforms.push(currentPlatformName);
+         
+        for (let key in Bootstrapper.supportedPlatforms) {
+            if (key !== platform)
+                orderedPlatforms.push(Bootstrapper.supportedPlatforms[key]);
+        }
+        
+        return orderedPlatforms;
+    }
+    
+    get buildFilename() : string {
+        return this._buildFilename;
+    }
+    
+    download(stream : NodeJS.WritableStream) : Thenable<boolean> {
+        return new Promise((resolve, reject) => {
+            
+            request
+            .get(this.baseUrl + this.platformName, {timeout:4000})
+            .on('response', function(response) {
+                if (response.statusCode === 200) 
+                    resolve(true);
+                else
+                    reject(response.statusMessage);
+            })
+            .on('error', function(e) {
+                reject(e);
+            })
+            .pipe(stream);
+        });
+    }
+}

--- a/src/cakeExtension.ts
+++ b/src/cakeExtension.ts
@@ -1,0 +1,51 @@
+'use strict';
+
+import {window, workspace, commands, ExtensionContext} from 'vscode';
+import * as path from 'path';
+import * as fs from 'fs';
+import {Bootstrapper} from './bootstrapper';
+
+export function activate(context: ExtensionContext) : void {
+
+	let disposable = commands.registerCommand('cake.bootstrapper', async () => {
+        
+        var platformName = await window.showQuickPick(Bootstrapper.getPlatformOptions(process.platform));
+        
+        if (platformName == null)
+            return;
+        
+        //check if there is an open folder in workspace
+        if (workspace.rootPath === undefined) {
+            window.showErrorMessage('You have not yet opened a folder.');
+            return;
+        }
+        
+        let bootstrapper = new Bootstrapper(platformName);
+        var buildFilePath = path.join(workspace.rootPath, bootstrapper.buildFilename);
+        
+        if (fs.existsSync(buildFilePath)) {
+            var option = await window.showWarningMessage(`Overwrite the existing ${bootstrapper.buildFilename} file in this folder ?`, 'Overwrite');
+            
+            if (option !== 'Overwrite')
+                return;
+        }
+        
+        var file = fs.createWriteStream(buildFilePath);
+        var result = await bootstrapper.download(file);
+
+        if (result) {
+            
+            if (process.platform !== 'win32')
+                fs.chmod(buildFilePath, 0o755);
+
+            window.showInformationMessage('Cake bootstrapper downloaded successfully');
+        } else {
+            window.showErrorMessage('Error downloading Cake bootstrapper');
+        }
+	});
+
+	context.subscriptions.push(disposable);
+}
+
+export function deactivate() {
+}

--- a/test/bootstrapper.test.ts
+++ b/test/bootstrapper.test.ts
@@ -1,0 +1,74 @@
+// 
+// Please refer to their documentation on https://mochajs.org/ for help.
+//
+import * as assert from 'assert';
+
+import {MemoryStream} from './memorystream';
+import {Bootstrapper} from '../src/bootstrapper';
+
+// Defines a Mocha test suite to group tests of similar kind together
+suite("Bootstrapper", () => {
+
+
+    suite("#getPlatformOptions()", () => {
+        test("should return OSX at first position when platform is darwin", () => {
+            let platforms = Bootstrapper.getPlatformOptions('darwin');
+            assert.strictEqual(platforms[0], 'OSX');
+        });
+        
+        test("should return Windows at first position when platform is win32", () => {
+            let platforms = Bootstrapper.getPlatformOptions('win32');
+            assert.strictEqual(platforms[0], 'Windows');
+        });
+        
+        test("should return Linux at first position when platform is linux", () => {
+            let platforms = Bootstrapper.getPlatformOptions('linux');
+            assert.strictEqual(platforms[0], 'Linux');
+        });
+        
+        test("should return all supported platforms, without a specific order, even if the current platform is unknown", () => {
+            let platforms = Bootstrapper.getPlatformOptions('my-new-os');
+            assert.strictEqual(platforms.length, 3);
+        });
+    });
+
+	// Defines a Mocha unit test
+    suite("#download()", () => {
+        test("should return build.ps1 in buildFilename property when platformName is Windows", () => {
+            let bt = new Bootstrapper("Windows");
+            assert.strictEqual(bt.buildFilename, 'build.ps1');
+        });
+        
+        test("should return build.sh in buildFilename property when platform name OSX", () => {
+            let bt = new Bootstrapper("OSX");
+            assert.strictEqual(bt.buildFilename, 'build.sh');
+        });
+        
+        test("should return build.sh in buildFilename property when platform name Linux", () => {
+            let bt = new Bootstrapper("Linux");
+            assert.strictEqual(bt.buildFilename, 'build.sh');
+        });
+        
+        test("should download OSX build script version", async () => {
+            let bt = new Bootstrapper("OSX");
+            let ms = new MemoryStream();
+            await bt.download(ms);
+            assert.equal(ms.toString().startsWith("#!/bin/bash"), true);
+        });
+        
+        test("should download Linux build script version", async () => {
+            let bt = new Bootstrapper("Linux");
+            let ms = new MemoryStream();
+            await bt.download(ms);
+            assert.equal(ms.toString().startsWith("#!/bin/bash"), true);
+        });
+        
+        test("should download PowerShell build script version", async () => {
+            let bt = new Bootstrapper("Windows");
+            let ms = new MemoryStream();
+            await bt.download(ms);
+            assert.equal(ms.toString().startsWith("<#"), true);
+        });
+    });
+    
+});

--- a/test/index.ts
+++ b/test/index.ts
@@ -1,0 +1,22 @@
+// 
+// PLEASE DO NOT MODIFY / DELETE UNLESS YOU KNOW WHAT YOU ARE DOING  
+//
+// This file is providing the test runner to use when running extension tests.
+// By default the test runner in use is Mocha based.
+// 
+// You can provide your own test runner if you want to override it by exporting
+// a function run(testRoot: string, clb: (error:Error) => void) that the extension
+// host can call to run the tests. The test runner is expected to use console.log
+// to report the results back to the caller. When the tests are finished, return
+// a possible error to the callback or null if none.
+
+var testRunner = require('vscode/lib/testrunner');
+
+// You can directly control Mocha options by uncommenting the following lines
+// See https://github.com/mochajs/mocha/wiki/Using-mocha-programmatically#set-options for more info
+testRunner.configure({
+	ui: 'tdd', 		// the TDD UI is being used in extension.test.ts (suite, test, etc.)
+	useColors: true // colored output from test results
+});
+
+module.exports = testRunner;

--- a/test/memorystream.ts
+++ b/test/memorystream.ts
@@ -1,0 +1,23 @@
+'use strict';
+
+import * as stream from "stream";
+
+export class MemoryStream extends stream.Writable {
+    
+    private memBuffer : Buffer;
+    constructor(opts?: stream.WritableOptions) {
+       super(opts);
+       this.memBuffer = new Buffer("");
+    }
+    
+    toString() : string {
+        return this.memBuffer.toString();
+    }
+    
+     _write(chunk: any, encoding: string, callback: Function): void {
+        let buffer = (Buffer.isBuffer(chunk)) ? chunk : new Buffer(chunk, encoding);
+        
+        this.memBuffer = Buffer.concat([this.memBuffer, buffer]);
+        callback();
+    }
+} 

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,13 @@
+{
+	"compilerOptions": {
+		"module": "commonjs",
+		"target": "es6",
+		"outDir": "out",
+		"noLib": true,
+		"sourceMap": true,
+        "rootDir": "."
+	},
+	"exclude": [
+		"node_modules"
+	]
+}

--- a/typings/node.d.ts
+++ b/typings/node.d.ts
@@ -1,0 +1,1 @@
+/// <reference path="../node_modules/vscode/typings/node.d.ts" />

--- a/typings/vscode-typings.d.ts
+++ b/typings/vscode-typings.d.ts
@@ -1,0 +1,1 @@
+/// <reference path="../node_modules/vscode/typings/index.d.ts" />


### PR DESCRIPTION
This command installs the Cake's bootstrapper to the platform selected
by user. The bootstrapper is downloaded from the Cake repository and
saved in the root folder.

Unfortunately the VSCode doesn't have a UI control that allow multiple
item selection, therefore the user needs to run the command for each
platform they needs the bootstrapper.

To make the user's life a little bit easier, the platform on which it
is running VSCode will always be displayed on top of the list, that way
he can select the item just pressing `ENTER`