### PR TITLE
GH25: Fix syntax highlighting on keywords

### DIFF
--- a/syntaxes/cake.json
+++ b/syntaxes/cake.json
@@ -298,7 +298,11 @@
         },
         {
           "match": "(Task|WithCriteria|Does|IsDependentOn|OnError|ContinueOnError|ReportError|Finally|Setup|Teardown|TaskSetup|TaskTeardown|RunTarget)\\(",
-          "name": "keyword.cake.cs"
+          "captures": {
+            "1": {
+              "name": "keyword.cake.cs"
+            }
+          }
         },
         {
           "match": "\\b(from|where|select|group|into|orderby|join|let|on|equals|by|ascending|descending)\\b",


### PR DESCRIPTION
The regex for matching keywords for syntax highlighting will include the trailing `(` and colorize it: 

![image](https://cloud.githubusercontent.com/assets/1361856/20412849/2b5cd6e0-ad21-11e6-956f-9694965e4a53.png)

This PR adds a capture to fix:

![image](https://cloud.githubusercontent.com/assets/1361856/20412894/7dba0f8e-ad21-11e6-8863-8d790f08e626.png)
