### PR TITLE
Added support for task execution.

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@ In addition to integrated editing features, the extension also provides commands
 
 * `Cake: Install a bootstrapper` to install a Cake bootstrapper for Windows, OS X or Linux in the root folder.
 * `Cake: Install a configuration file` to install the default Cake Configuration file for controlling internal components of Cake.
+* `Cake: Execute task` to execute task in build.cake.
 
 ## What is Cake?
 

--- a/package.json
+++ b/package.json
@@ -30,7 +30,8 @@
   ],
   "activationEvents": [
     "onCommand:cake.bootstrapper",
-    "onCommand:cake.configuration"
+    "onCommand:cake.configuration",
+    "onCommand:cake.execution"
   ],
   "main": "./out/src/cakeMain",
   "contributes": {
@@ -73,6 +74,10 @@
       {
         "command": "cake.configuration",
         "title": "Cake: Install a configuration file"
+      }, 
+      {
+        "command": "cake.execution",
+        "title": "Cake: Execute task"
       }
     ],
     "outputChannels": [

--- a/src/cakeMain.ts
+++ b/src/cakeMain.ts
@@ -3,6 +3,7 @@
 import { commands, ExtensionContext } from 'vscode';
 import { installCakeBootstrapper } from './bootstrapper/cakeBootstrapperCommand';
 import { installCakeConfiguration } from './configuration/cakeConfigurationCommand';
+import { installCakeExecutor } from "./execution/cakeExecutorCommand";
 
 export function activate(context: ExtensionContext): void {
     // Register the bootstrapper command.
@@ -13,7 +14,11 @@ export function activate(context: ExtensionContext): void {
     context.subscriptions.push(commands.registerCommand('cake.configuration', async () => {
         installCakeConfiguration();
     }));
+    // Register the exeuction command.
+    context.subscriptions.push(commands.registerCommand("cake.execution", async() => {
+        installCakeExecutor();
+    }));
 }
 
-export function deactivate() {
+export function deactivate() { 
 }

--- a/src/execution/cakeExecutor.ts
+++ b/src/execution/cakeExecutor.ts
@@ -1,0 +1,117 @@
+import * as vscode from "vscode";
+import * as os from "os";
+
+export class CakeExecutor {
+    private eol = "\n";
+    private windows = os.platform() === "win32";
+    private staticBarItem: vscode.StatusBarItem;
+    private tasks: vscode.QuickPickItem[] = [];
+    private watcher: vscode.FileSystemWatcher;
+
+    constructor(commandId) {
+        this.initialize(commandId)
+    }
+
+    private createBuildCommand(taskName) {
+        if (this.windows) {
+            return `powershell -ExecutionPolicy ByPass -File build.ps1 -target \"${taskName}\"`;
+
+        } else {
+            return `./build.sh --target \"${taskName}\"`;
+        }
+    }
+
+    private findTasks(text: string): string[] {
+        let lines = text.split(this.eol);
+        let taskLines = lines.filter(x => x.indexOf("Task(\"") !== -1);
+        let tasks = taskLines.map(x => x.match(/"(.*?)"/)[1]);
+        return tasks;
+    }
+
+    private updateTask(file: vscode.Uri) {
+        let open = vscode.workspace.openTextDocument(file.fsPath);
+        open.then(file => {
+            let text = file.getText();
+            let tasks = this.findTasks(text)
+            this.tasks = [];
+
+            tasks.forEach(x => {
+                let task = { label: x, description: "" };
+                this.tasks.push(task);
+            });
+        });
+    }
+
+    private async initializeTasks() {
+        let find = vscode.workspace.findFiles("build.cake", "**/node_modules/**", 1);
+
+        return new Promise<vscode.Uri>((resolve, reject) => {
+            find.then(files => {
+                if (files.length > 0) {
+                    resolve(files[0]);
+                }
+            })
+        });
+    }
+
+    private showTerminal() {
+        vscode.commands.executeCommand("workbench.action.terminal.focus");
+    }
+
+    private runCommand(result) {
+        let editor = vscode.window.activeTextEditor;
+        let document = editor.document;
+        let eol = editor.document.lineCount + 1;
+        let position = editor.selection.active;
+        var startPos = new vscode.Position(eol, 0);
+        var endPos = new vscode.Position(eol, result.length);
+        var selStartPos = new vscode.Position(eol - 1, 0);
+        var newSelection = new vscode.Selection(selStartPos, endPos);
+        editor.edit((edits) => {
+            edits.insert(startPos, '\n' + result);
+        }).then(() => {
+            this.showTerminal();
+            vscode.commands.executeCommand("workbench.action.focusActiveEditorGroup");
+            editor.selection = newSelection;
+            vscode.commands.executeCommand('workbench.action.terminal.runSelectedText');
+            vscode.commands.executeCommand('undo');
+        }, ()  => {
+            vscode.window.showErrorMessage("Unable to run task");
+        })
+    }
+
+    private async initialize(commandId) {
+        var uri = await this.initializeTasks();
+        this.updateTask(uri);
+
+        this.watcher = vscode.workspace.createFileSystemWatcher("**/*.cake");
+        this.watcher.onDidChange(uri => {
+            this.updateTask(uri);
+        });
+
+        if (!this.staticBarItem) {
+            this.staticBarItem = vscode.window.createStatusBarItem(vscode.StatusBarAlignment.Left);
+            this.staticBarItem.text = "$(terminal) Cake";
+            this.staticBarItem.command = commandId;
+            this.staticBarItem.show();
+        }
+    }
+
+    public showTasks() {
+        let options = { placeholder: "Select task name" };
+        let quickPick = vscode.window.showQuickPick(this.tasks, options);
+        quickPick.then(result => {
+            if(result !== undefined) {
+                var task = result.label;
+                var command = this.createBuildCommand(task);
+                this.runCommand(command);
+            }
+        });
+    }
+
+    dispose() {
+        this.watcher.dispose();
+        this.staticBarItem.dispose();
+        this.tasks = [];
+    }
+}

--- a/src/execution/cakeExecutorCommand.ts
+++ b/src/execution/cakeExecutorCommand.ts
@@ -1,0 +1,22 @@
+import {window, workspace, commands, ExtensionContext} from 'vscode';
+import * as path from 'path';
+import * as fs from 'fs';
+import {CakeExecutor} from './cakeExecutor';
+
+let cake = new CakeExecutor("cake.execution");
+
+export async function installCakeExecutor()
+{
+  // Check if there is an open folder in workspace
+  if (workspace.rootPath === undefined) {
+      window.showErrorMessage('You have not yet opened a folder.');
+      return;
+  }
+
+  if(window.activeTextEditor == undefined) {
+      window.showErrorMessage('You have not yet opened any file.');
+      return;
+  }
+
+  cake.showTasks();
+}


### PR DESCRIPTION
(move from vscode-cake-runner: https://github.com/wk-j/vscode-cake-runner/issues/2)

This feature allow user to  select task to execute by select “Cake: Execute task” in Command Palette.
Selected task will execute on Terminal, its also active Terminal window if not exist.