### PR TITLE
Update .gitignore for tools folder (Issue #66)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,12 +5,8 @@ node_modules
 
 # Build related
 build-results/
-tools/Cake/
-tools/nuget.exe
-tools/gitreleasemanager/
-tools/GitVersion.CommandLine/
-tools/Addins/
-tools/packages.config.md5sum
+tools/**
+!tools/packages.config
 
 # until we move to Yarn
 yarn.lock


### PR DESCRIPTION
In line with the recommended way of excluding things from the
github example .gitignore
https://github.com/github/gitignore/blob/master/VisualStudio.gitignore

Issue #66 