### PR TITLE
Feature/dont update version on local build issue #70

### DIFF
--- a/build.cake
+++ b/build.cake
@@ -95,6 +95,7 @@ Task("Create-Release-Notes")
 });
 
 Task("Update-Project-Json-Version")
+    .WithCriteria(() => !parameters.IsLocalBuild)
     .Does(() =>
 {
     var projectToPackagePackageJson = "package.json";

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "cake-vscode",
-  "version": "0.9.0-GH-55-0001",
+  "version": "0.1.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "displayName": "Cake",
   "publisher": "cake-build",
   "description": "Cake build script language support.",
-  "version": "0.10.1-beta0001",
+  "version": "0.1.0",
   "icon": "images/cake.png",
   "private": true,
   "author": {


### PR DESCRIPTION
Instead of setting a new version number and committing a new
package.json after every local build, modify the task to only
update version number when running CI-builds.