### PR TITLE
Update cakeRunTaskCommand.ts to fix --script parameter

### DIFF
--- a/src/codeLens/cakeRunTaskCommand.ts
+++ b/src/codeLens/cakeRunTaskCommand.ts
@@ -9,7 +9,7 @@ export async function installCakeRunTaskCommand(
     const buildCommand =
         os.platform() === 'win32'
             ? `powershell -ExecutionPolicy ByPass -File build.ps1 -script \"${fileName}\" -target \"${taskName}\" -verbosity ${runConfig.verbosity}`
-            : `./build.sh --script=\"${fileName}\" --target=\"${taskName}\" --verbosity=${runConfig.verbosity}`;
+            : `./build.sh --script \"${fileName}\" --target=\"${taskName}\" --verbosity=${runConfig.verbosity}`;
 
     TerminalExecutor.runInTerminal(buildCommand);
 }


### PR DESCRIPTION
Because of `-s|--script) SCRIPT="$2"; shift ;;` in `build.sh` without a space after `--script` the entire `--script="<path>"` is treated as a singular parameter on macOS High Sierra v.10.13.6. Did not test other systems, though this should work just fine, as `--script` is a special parameter.