### PR TITLE
(GH-432) Add additional bootstrapper downloads

### DIFF
--- a/package.json
+++ b/package.json
@@ -112,8 +112,12 @@
         "cake.bootstrappers": {
           "type": "object",
           "default": {
-            "powershell": "https://cakebuild.net/download/bootstrapper/powershell",
-            "bash": "https://cakebuild.net/download/bootstrapper/bash"
+            "dotnet-framework-powershell": "https://cakebuild.net/download/bootstrapper/dotnet-framework/powershell",
+            "dotnet-framework-bash": "https://cakebuild.net/download/bootstrapper/dotnet-framework/bash",
+            "dotnet-core-powershell": "https://cakebuild.net/download/bootstrapper/dotnet-core/powershell",
+            "dotnet-core-bash": "https://cakebuild.net/download/bootstrapper/dotnet-core/bash",
+            "dotnet-tool-powershell": "https://cakebuild.net/download/bootstrapper/dotnet-tool/powershell",
+            "dotnet-tool-bash": "https://cakebuild.net/download/bootstrapper/dotnet-tool/bash"
           },
           "description": "The Cake bootstrapper URIs."
         },
@@ -419,13 +423,13 @@
     "@types/mocha": "^8.0.3",
     "@types/node": "^14.14.6",
     "@types/node-fetch": "^2.5.7",
+    "@types/vscode": "^1.24.0",
     "@types/xml2js": "^0.4.5",
     "expect": "^26.6.2",
     "mocha": "^8.2.1",
     "tslint": "^6.1.3",
     "typemoq": "^2.1.0",
     "typescript": "^4.0.5",
-    "@types/vscode": "^1.24.0",
     "vscode-test": "^1.4.0"
   },
   "extensionDependencies": [

--- a/src/bootstrapper/cakeBootstrapper.ts
+++ b/src/bootstrapper/cakeBootstrapper.ts
@@ -8,16 +8,44 @@ export class CakeBootstrapper {
 
     private static bootstrappers = [
         new CakeBootstrapperInfo(
-            'powershell',
-            'PowerShell',
-            'Bootstrapper for Windows',
+            'dotnet-tool-powershell',
+            '.NET Tool runner PowerShell',
+            'Bootstrapper for .NET Tool on Windows',
             'build.ps1',
             false
         ),
         new CakeBootstrapperInfo(
-            'bash',
-            'Bash',
-            'Bootstrapper for Linux and OSX',
+            'dotnet-tool-bash',
+            '.NET Tool runner Bash',
+            'Bootstrapper for .NET Tool on Linux and macOS',
+            'build.sh',
+            true
+        ),
+        new CakeBootstrapperInfo(
+            'dotnet-framework-powershell',
+            '.NET Framework runner PowerShell',
+            'Bootstrapper for .NET Framework on Windows',
+            'build.ps1',
+            false
+        ),
+        new CakeBootstrapperInfo(
+            'dotnet-framework-bash',
+            '.NET Framework runner Bash',
+            'Bootstrapper for .NET Framework (Mono) on Linux and macOS',
+            'build.sh',
+            true
+        ),
+        new CakeBootstrapperInfo(
+            'dotnet-core-powershell',
+            '.NET Core runner PowerShell',
+            'Bootstrapper for .NET Core on Windows',
+            'build.ps1',
+            false
+        ),
+        new CakeBootstrapperInfo(
+            'dotnet-core-bash',
+            '.NET Core runner Bash',
+            'Bootstrapper for .NET Core on Linux and macOS',
             'build.sh',
             true
         )


### PR DESCRIPTION
Now that bootstrapper stubs exists on the resources repository, and the
additional redirects have been added into the Cake website, provide the
ability to download these from the bootstrapper command.

Fixes #432