### PR TITLE
(GH-93) Handle empty lines when reading file stream

### DIFF
--- a/src/addPackage/actions/handleDirectiveWithContent.ts
+++ b/src/addPackage/actions/handleDirectiveWithContent.ts
@@ -32,7 +32,7 @@ function _getFileContentWithDirective(
         const fileStream = fs.createReadStream(pickedFilePath, {
             encoding: 'utf8'
         });
-        const stream = byline(fileStream);
+        const stream = byline(fileStream, { keepEmptyLines: true });
         let content: Array<string> = [];
         let containDirective = false;
         stream.on('data', line => {


### PR DESCRIPTION
By default, the byline library ignores empty lines, and doesn't do
anything with them. Since we want to keep these, we need to add the
keepEmptyLines option.

Fixes #93 