### PR TITLE
(GH-143) added buildScript setting

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,9 +76,10 @@ There are a number of configuration options which allow you to control how the T
 * `cake.taskRunner.scriptsIncludePattern`: a glob pattern which specifies how to detect `.cake` files in the current workspace. Default value is `**/*.cake`.
 * `cake.taskRunner.scriptsExcludePattan`: a glob pattern which specifies all files and folders that shouldn't be included in search of current workspace.  Default value is `""`.
 * `cake.taskRunner.taskRegularExpression`: a regular expression pattern which is used to identify Tasks within the `*.cake` files. Default value is `Task\\s*?\\(\\s*?\"(.*?)\"\\s*?\\)`.
-* `cake.taskRunner.buildScript`: the name of the build script to run, when running a task. 
+* `cake.taskRunner.launchCommand`: the name of the build script to run, when running a task.
   This is a complex object, consisting of at least one property `default` and optionally properties corresponding to values of [`os.platform()`](https://nodejs.org/api/os.html#os_os_platform) for non-default values specific to different platforms.
   Default value is `null` which is equal to specifying `{"default": "./build.sh", "win32": "powershell -ExecutionPolicy ByPass -File build.ps1"}`.
+* `cake.taskRunner.verbosity`: allows you to control cake `run task` verbosity (`diagnostic`, `minimal`, `normal`, `quiet` and `verbose`. Default value is `normal`.
 
 ### Codelens
 
@@ -89,7 +90,6 @@ There are a number of configuration options which allow you to control the Cake 
 * `cake.codeLens.showCodeLens`: a boolean value which toggles codelens on or off. Default value is `true`.
 * `cake.codeLens.scriptsIncludePattern`: a glob pattern which specifies how to detect `.cake` files in the current workspace. Default value is `**/*.cake`.
 * `cake.codeLens.taskRegularExpression`: a regular expression pattern which is used to identify Tasks within the `*.cake` files. Default value is `Task\\s*?\\(\\s*?\"(.*?)\"\\s*?\\)`.
-* `cake.codeLens.runTask.verbosity`: allows you to control cake `run task` verbosity (`diagnostic`, `minimal`, `normal`, `quiet` and `verbose`. Default value is `normal`.
 * `cake.codeLens.debugTask.verbosity`: allows you to control cake `debug task` verbosity (`diagnostic`, `minimal`, `normal`, `quiet` and `verbose`. Default value is `normal`.
 * `cake.codeLens.debugTask.debugType`: framework type of the debug session (`mono`or `coreclr`). Default value is `coreclr`.
 * `cake.codeLens.debugTask.request`: request type of the debug session. Default value is `launch`.
@@ -104,7 +104,7 @@ There are a number of configuration options which allow you to control the Cake 
 * `cake.codeLens.debugTask.logging.browserStdOut`: flag to determine if stdout text from the launching the web browser should be logged to the output window. Default value is `false`.
 
 **Remark**: While the command to debug a task is configurable using the `cake.codeLens.debugTask.program` setting,
-there is no specific setting for configuring the command to run a task. For this case the `cake.taskRunner.buildScript` setting is used (see above).
+there is no specific setting for configuring the command to run a task. For this case the `cake.taskRunner.launchCommand` setting is used (see above).  In addition, the verbosity used with running a task is controlled via the `cake.taskRunner.verbosity` setting.
 
 ## Resource Video
 

--- a/README.md
+++ b/README.md
@@ -76,6 +76,9 @@ There are a number of configuration options which allow you to control how the T
 * `cake.taskRunner.scriptsIncludePattern`: a glob pattern which specifies how to detect `.cake` files in the current workspace. Default value is `**/*.cake`.
 * `cake.taskRunner.scriptsExcludePattan`: a glob pattern which specifies all files and folders that shouldn't be included in search of current workspace.  Default value is `""`.
 * `cake.taskRunner.taskRegularExpression`: a regular expression pattern which is used to identify Tasks within the `*.cake` files. Default value is `Task\\s*?\\(\\s*?\"(.*?)\"\\s*?\\)`.
+* `cake.taskRunner.buildScript`: the name of the build script to run, when running a task. 
+  This is a complex object, consisting of at least one property `default` and optionally properties corresponding to values of [`os.platform()`](https://nodejs.org/api/os.html#os_os_platform) for non-default values specific to different platforms.
+  Default value is `null` which is equal to specifying `{"default": "./build.sh", "win32": "powershell -ExecutionPolicy ByPass -File build.ps1"}`.
 
 ### Codelens
 
@@ -99,6 +102,9 @@ There are a number of configuration options which allow you to control the Cake 
 * `cake.codeLens.debugTask.logging.programOutput`: flag to determine whether program output should be logged to the output window when not using an external console. Default value is `false`.
 * `cake.codeLens.debugTask.logging.engineLogging`: flag to determine whether program output should be logged to the output window when not using an external console. Default value is `false`.
 * `cake.codeLens.debugTask.logging.browserStdOut`: flag to determine if stdout text from the launching the web browser should be logged to the output window. Default value is `false`.
+
+**Remark**: While the command to debug a task is configurable using the `cake.codeLens.debugTask.program` setting,
+there is no specific setting for configuring the command to run a task. For this case the `cake.taskRunner.buildScript` setting is used (see above).
 
 ## Resource Video
 

--- a/package.json
+++ b/package.json
@@ -106,7 +106,8 @@
             "scriptsIncludePattern": "**/*.cake",
             "scriptsExcludePattern": "",
             "taskRegularExpression": "Task\\s*?\\(\\s*?\"(.*?)\"\\s*?\\)",
-            "buildScript": null
+            "buildScript": null,
+            "verbosity": "normal"
           },
           "description": "The Cake Task Runner settings"
         },

--- a/package.json
+++ b/package.json
@@ -105,7 +105,8 @@
             "autoDetect": true,
             "scriptsIncludePattern": "**/*.cake",
             "scriptsExcludePattern": "",
-            "taskRegularExpression": "Task\\s*?\\(\\s*?\"(.*?)\"\\s*?\\)"
+            "taskRegularExpression": "Task\\s*?\\(\\s*?\"(.*?)\"\\s*?\\)",
+            "buildScript": null
           },
           "description": "The Cake Task Runner settings"
         },

--- a/package.json
+++ b/package.json
@@ -106,7 +106,7 @@
             "scriptsIncludePattern": "**/*.cake",
             "scriptsExcludePattern": "",
             "taskRegularExpression": "Task\\s*?\\(\\s*?\"(.*?)\"\\s*?\\)",
-            "buildScript": null,
+            "launchCommand": null,
             "verbosity": "normal"
           },
           "description": "The Cake Task Runner settings"
@@ -152,9 +152,6 @@
                 "engineLogging": false,
                 "browserStdOut": false
               }
-            },
-            "runTask": {
-              "verbosity": "normal"
             }
           },
           "properties": {
@@ -172,31 +169,6 @@
               "type": "string",
               "description": "Regular expression pattern to get tasks from Cake script",
               "default": "Task\\s*?\\(\\s*?\"(.*?)\"\\s*?\\)"
-            },
-            "runTask": {
-              "type": "object",
-              "description": "Cake run task configuration",
-              "properties": {
-                "verbosity": {
-                  "type": "string",
-                  "description": "Represents Cake run task output verbosity",
-                  "enum": [
-                    "diagnostic",
-                    "minimal",
-                    "normal",
-                    "quiet",
-                    "verbose"
-                  ],
-                  "enumDescriptions": [
-                    "Diagnostic verbosity",
-                    "Minimal verbosity.",
-                    "Normal verbosity.",
-                    "Quiet verbosity.",
-                    "Verbose verbosity."
-                  ],
-                  "default": "diagnostic"
-                }
-              }
             },
             "debugTask": {
               "type": "object",

--- a/src/cakeMain.ts
+++ b/src/cakeMain.ts
@@ -164,7 +164,7 @@ async function _getCakeScriptsAsTasks(): Promise<vscode.Task[]> {
                     script: taskName
                 };
 
-                const buildCommand = `${buildCommandBase} --target=\"${taskName}\"`;
+                const buildCommand = `${buildCommandBase} \"${file.fsPath}\"  --target=\"${taskName}\" --verbosity=${config.verbosity}`;
 
                 const buildTask = new vscode.Task(
                     kind,

--- a/src/cakeMain.ts
+++ b/src/cakeMain.ts
@@ -156,7 +156,7 @@ async function _getCakeScriptsAsTasks(): Promise<vscode.Task[]> {
                 taskNames.push(matches[1]);
             }
 
-            const buildCommandBase = config.buildScript[os.platform()] || config.buildScript.default;
+            const buildCommandBase = config.launchCommand[os.platform()] || config.launchCommand.default;
 
             taskNames.forEach(taskName => {
                 const kind: CakeTaskDefinition = {

--- a/src/codeLens/cakeRunTaskCommand.ts
+++ b/src/codeLens/cakeRunTaskCommand.ts
@@ -8,7 +8,7 @@ export async function installCakeRunTaskCommand(
     settings: IExtensionSettings
 ) {
     let buildCommand = settings.taskRunner.buildScript[os.platform()] || settings.taskRunner.buildScript.default;
-    buildCommand = `${buildCommand} --script=\"${fileName}\" --target=\"${taskName}\" --verbosity=${settings.codeLens.runTask.verbosity}`;
+    buildCommand = `${buildCommand} \"${fileName}\" --target=\"${taskName}\" --verbosity=${settings.codeLens.runTask.verbosity}`;
 
     TerminalExecutor.runInTerminal(buildCommand);
 }

--- a/src/codeLens/cakeRunTaskCommand.ts
+++ b/src/codeLens/cakeRunTaskCommand.ts
@@ -7,8 +7,8 @@ export async function installCakeRunTaskCommand(
     fileName: string,
     settings: IExtensionSettings
 ) {
-    let buildCommand = settings.taskRunner.buildScript[os.platform()] || settings.taskRunner.buildScript.default;
-    buildCommand = `${buildCommand} \"${fileName}\" --target=\"${taskName}\" --verbosity=${settings.codeLens.runTask.verbosity}`;
+    let buildCommand = settings.taskRunner.launchCommand[os.platform()] || settings.taskRunner.launchCommand.default;
+    buildCommand = `${buildCommand} \"${fileName}\" --target=\"${taskName}\" --verbosity=${settings.taskRunner.verbosity}`;
 
     TerminalExecutor.runInTerminal(buildCommand);
 }

--- a/src/codeLens/cakeRunTaskCommand.ts
+++ b/src/codeLens/cakeRunTaskCommand.ts
@@ -1,15 +1,14 @@
 import * as os from 'os';
+import { IExtensionSettings } from '../extensionSettings';
 import { TerminalExecutor } from '../shared/utils';
 
 export async function installCakeRunTaskCommand(
     taskName: string,
     fileName: string,
-    runConfig: any
+    settings: IExtensionSettings
 ) {
-    const buildCommand =
-        os.platform() === 'win32'
-            ? `powershell -ExecutionPolicy ByPass -File build.ps1 -script \"${fileName}\" -target \"${taskName}\" -verbosity ${runConfig.verbosity}`
-            : `./build.sh --script \"${fileName}\" --target=\"${taskName}\" --verbosity=${runConfig.verbosity}`;
+    let buildCommand = settings.taskRunner.buildScript[os.platform()] || settings.taskRunner.buildScript.default;
+    buildCommand = `${buildCommand} --script=\"${fileName}\" --target=\"${taskName}\" --verbosity=${settings.codeLens.runTask.verbosity}`;
 
     TerminalExecutor.runInTerminal(buildCommand);
 }

--- a/src/extensionSettings.ts
+++ b/src/extensionSettings.ts
@@ -1,0 +1,94 @@
+import * as vscode from 'vscode';
+
+interface IBuildScriptSettings {
+    default: string;
+    [platform: string]: string;
+}
+
+export interface ITaskRunnerSettings {
+    autoDetect: boolean;
+    scriptsIncludePattern: string;
+    scriptsExcludePattern: string;
+    taskRegularExpression: string;
+    buildScript: IBuildScriptSettings;
+}
+
+export interface IBootstrappersSettings {
+    "dotnet-framework-powershell": string;
+    "dotnet-framework-bash": string;
+    "dotnet-core-powershell": string;
+    "dotnet-core-bash": string;
+    "dotnet-tool-powershell": string;
+    "dotnet-tool-bash": string;
+}
+
+export interface IConfigurationSettings {
+    config: string;
+}
+
+export interface ICodeLensDebugTaskSettings {
+    verbosity: "diagnostic" | "minimal" | "normal" | "quiet" | "verbose";
+    debugType: "mono" | "coreclr";
+    request: string; // really?
+    program: string;
+    cwd: string;
+    stopAtEntry: boolean;
+    console: "internalConsole" | "integratedTerminal" | "externalTerminal";
+    logging: {
+        exceptions: boolean;
+        moduleLoad: boolean;
+        programOutput: boolean;
+        engineLogging: boolean;
+        browserStdOut: boolean;
+    }
+}
+
+export interface ICodeLensSettings {
+    showCodeLens: boolean;
+    scriptsIncludePattern: string;
+    taskRegularExpression: string;
+    debugTask: ICodeLensDebugTaskSettings;
+    runTask: {
+        verbosity: "diagnostic" | "minimal" | "normal" | "quiet" | "verbose";
+    };
+}
+
+export interface IExtensionSettings {
+    taskRunner: ITaskRunnerSettings;
+    bootstrappers: IBootstrappersSettings;
+    configuration: IConfigurationSettings;
+    codeLens: ICodeLensSettings;
+}
+
+export function getExtensionSettings(): IExtensionSettings {
+    var settings = vscode.workspace.getConfiguration('cake') as unknown as IExtensionSettings;
+    var taskRunner = settings.taskRunner;
+
+    // extend "cake.taskRunner.buildScript" here, because the default of `{"default":"...", "win32":"..."}`
+    // can not (!) be part of the vs-internal settings defaults or else the platform-specific setting 
+    // can never be overridden. (i.e. win32 will always be set.)
+    const defaultScript = "./build.sh"; 
+    let buildScript = settings.taskRunner.buildScript;
+    if(!buildScript) {
+        buildScript = {
+            default: defaultScript,
+            win32: "powershell -ExecutionPolicy ByPass -File build.ps1"
+        }
+    }
+
+    // make sure that there is always "cake.taskRunner.buildScript.default" - even if it's not in the settings.
+    if(!buildScript.default){
+        buildScript = {
+            ...buildScript,
+            default: defaultScript
+        }
+    }
+
+    return {
+        ...settings,
+        taskRunner: {
+            ...taskRunner,
+            buildScript
+        }
+    }
+}

--- a/src/extensionSettings.ts
+++ b/src/extensionSettings.ts
@@ -11,6 +11,7 @@ export interface ITaskRunnerSettings {
     scriptsExcludePattern: string;
     taskRegularExpression: string;
     buildScript: IBuildScriptSettings;
+    verbosity: "diagnostic" | "minimal" | "normal" | "quiet" | "verbose";
 }
 
 export interface IBootstrappersSettings {
@@ -29,7 +30,7 @@ export interface IConfigurationSettings {
 export interface ICodeLensDebugTaskSettings {
     verbosity: "diagnostic" | "minimal" | "normal" | "quiet" | "verbose";
     debugType: "mono" | "coreclr";
-    request: string; // really?
+    request: string;
     program: string;
     cwd: string;
     stopAtEntry: boolean;
@@ -65,9 +66,9 @@ export function getExtensionSettings(): IExtensionSettings {
     var taskRunner = settings.taskRunner;
 
     // extend "cake.taskRunner.buildScript" here, because the default of `{"default":"...", "win32":"..."}`
-    // can not (!) be part of the vs-internal settings defaults or else the platform-specific setting 
+    // can not (!) be part of the vs-internal settings defaults or else the platform-specific setting
     // can never be overridden. (i.e. win32 will always be set.)
-    const defaultScript = "./build.sh"; 
+    const defaultScript = "./build.sh";
     let buildScript = settings.taskRunner.buildScript;
     if(!buildScript) {
         buildScript = {

--- a/src/extensionSettings.ts
+++ b/src/extensionSettings.ts
@@ -1,6 +1,6 @@
 import * as vscode from 'vscode';
 
-interface IBuildScriptSettings {
+interface ILaunchCommandSettings {
     default: string;
     [platform: string]: string;
 }
@@ -10,7 +10,7 @@ export interface ITaskRunnerSettings {
     scriptsIncludePattern: string;
     scriptsExcludePattern: string;
     taskRegularExpression: string;
-    buildScript: IBuildScriptSettings;
+    launchCommand: ILaunchCommandSettings;
     verbosity: "diagnostic" | "minimal" | "normal" | "quiet" | "verbose";
 }
 
@@ -49,9 +49,6 @@ export interface ICodeLensSettings {
     scriptsIncludePattern: string;
     taskRegularExpression: string;
     debugTask: ICodeLensDebugTaskSettings;
-    runTask: {
-        verbosity: "diagnostic" | "minimal" | "normal" | "quiet" | "verbose";
-    };
 }
 
 export interface IExtensionSettings {
@@ -65,23 +62,23 @@ export function getExtensionSettings(): IExtensionSettings {
     var settings = vscode.workspace.getConfiguration('cake') as unknown as IExtensionSettings;
     var taskRunner = settings.taskRunner;
 
-    // extend "cake.taskRunner.buildScript" here, because the default of `{"default":"...", "win32":"..."}`
+    // extend "cake.taskRunner.launchCommand" here, because the default of `{"default":"...", "win32":"..."}`
     // can not (!) be part of the vs-internal settings defaults or else the platform-specific setting
     // can never be overridden. (i.e. win32 will always be set.)
-    const defaultScript = "./build.sh";
-    let buildScript = settings.taskRunner.buildScript;
-    if(!buildScript) {
-        buildScript = {
-            default: defaultScript,
+    const defaultCommand = "./build.sh";
+    let launchCommand = settings.taskRunner.launchCommand;
+    if (!launchCommand) {
+        launchCommand = {
+            default: defaultCommand,
             win32: "powershell -ExecutionPolicy ByPass -File build.ps1"
         }
     }
 
-    // make sure that there is always "cake.taskRunner.buildScript.default" - even if it's not in the settings.
-    if(!buildScript.default){
-        buildScript = {
-            ...buildScript,
-            default: defaultScript
+    // make sure that there is always "cake.taskRunner.launchCommand.default" - even if it's not in the settings.
+    if (!launchCommand.default) {
+        launchCommand = {
+            ...launchCommand,
+            default: defaultCommand
         }
     }
 
@@ -89,7 +86,7 @@ export function getExtensionSettings(): IExtensionSettings {
         ...settings,
         taskRunner: {
             ...taskRunner,
-            buildScript
+            launchCommand: launchCommand
         }
     }
 }


### PR DESCRIPTION
to configure the build script to be used for "Code Lens" and "Run Task"

fixes #143 
fixes #409 

This PR makes configuration of the build script for the "Run Task" command and for "Code Lens" possible.
Currently both are fixed to `./build.sh` for non-Windows and `powershell [...] build.ps1` for Windows.

Using this modification it is possible to have different configurations for the build script using a default value and also using platform-dependent values.

The "current" build script as given in the code would translate to the followin setting of `cake.taskRunner.buildScript`:
```json
{
  "default": "./build.sh",
  "win32": "powershell -ExecutionPolicy ByPass -File build.ps1"
}
```

However, if this was to be set in `package.json`, the setting would always contain a value for `win32`. Therefore the default for `cake.taskRunner.buildScript` is `null` (or not configured) and the runtime-default (of the above given configuration) is set in [`ExtensionSettings.ts#L72`](https://github.com/cake-build/cake-vscode/pull/436/files#diff-5a8bf3508356edfb00a50da17f995bd669f4fbe63e72727e88317e5f8be679e2R72).

One example for an alternate configuration *could* be:
```json
{
  "default": "dotnet cake",
  "darwin": "./build.sh"
}
```

using the .NET global tool for all paltforms except OSX/macOS in which case the `build.sh` would be used.

`default` is a "required" property and will always be set (see [`ExtensionSettings.ts#L83`](https://github.com/cake-build/cake-vscode/pull/436/files#diff-5a8bf3508356edfb00a50da17f995bd669f4fbe63e72727e88317e5f8be679e2R83)) while the other properties of the `cake.taskRunner.buildScript` object should correspond to one of the values of [`os.platform()`](https://nodejs.org/api/os.html#os_os_platform).