### PR TITLE
(GH-376) CodeLens debugging using global tool

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ In addition to integrated editing features, the extension also provides commands
 
 * `Cake: Install a bootstrapper` to install a Cake bootstrapper for Windows, OS X or Linux in the root folder.
 * `Cake: Install to workspace` will run through all of the available commands at once, to save having to run them one by one
-* `Cake: Install debug dependencies` to download the Cake.CoreCLR NuGet Package into the tools folder, ready for enabling debugging
+* `Cake: Install debug dependencies` to either install the .NET global tool or alternatively download the Cake.CoreCLR NuGet Package into the tools folder.
 * `Cake: Install sample build file` to install a sample Cake File that contains Setup and Teardown actions, a sample task, and argument parsing.
 * `Cake: Add addin from NuGet` to add or update an Addin from NuGet in the specified Cake file.
 * `Cake: Add tool from NuGet` to add or update a Tool from NuGet in the specified Cake file.

--- a/README.md
+++ b/README.md
@@ -93,7 +93,9 @@ There are a number of configuration options which allow you to control the Cake 
 * `cake.codeLens.debugTask.verbosity`: allows you to control cake `debug task` verbosity (`diagnostic`, `minimal`, `normal`, `quiet` and `verbose`. Default value is `normal`.
 * `cake.codeLens.debugTask.debugType`: framework type of the debug session (`mono`or `coreclr`). Default value is `coreclr`.
 * `cake.codeLens.debugTask.request`: request type of the debug session. Default value is `launch`.
-* `cake.codeLens.debugTask.program`: executable of the debug session (`tools/Cake/Cake.exe` for `mono` or `tools/Cake.CoreCLR/Cake.dll` for `coreclr`). Default value is `${workspaceRoot}/tools/Cake.CoreCLR/Cake.dll`.
+* `cake.codeLens.debugTask.program`: executable of the debug session (e.g. `tools/Cake/Cake.exe` for debugType `mono` or `tools/Cake.CoreCLR/Cake.dll` for debugType `coreclr`). 
+  This is a complex object, consisting of at least one property `default` and optionally properties corresponding to values of [`os.platform()`](https://nodejs.org/api/os.html#os_os_platform) for non-default values specific to different platforms.
+  Default value is `null` which is equal to specifying `{"default": "~/.dotnet/tools/dotnet-cake", "win32": "dotnet-cake.exe"}`.
 * `cake.codeLens.debugTask.cwd`: path to the working directory of the program being debugged. Default value is `${workspaceRoot}`.
 * `cake.codeLens.debugTask.stopAtEntry`: if true, the debugger should stop at the entry point of the target. Default value is `true`.
 * `cake.codeLens.debugTask.console`: console used by the debugger (`internalConsole`, `integratedTerminal` or `externalTerminal`) . Default value is `internalConsole`.

--- a/package.json
+++ b/package.json
@@ -515,11 +515,57 @@
     },
     "debuggers": [
       {
+        "type": "cake-tool",
+        "label": "Cake Tool",
+        "initialConfigurations": [
+          {
+            "name": "Cake: Debug Script (.NET Tool)",
+            "type": "coreclr",
+            "request": "launch",
+            "program": "dotnet-cake",
+            "windows": {
+              "program": "dotnet-cake.exe"
+            },
+            "args": [
+              "${workspaceRoot}/build.cake",
+              "--debug",
+              "--verbosity=diagnostic"
+            ],
+            "cwd": "${workspaceRoot}",
+            "stopAtEntry": true,
+            "externalConsole": false
+          }
+        ],
+        "configurationSnippets": [
+          {
+            "label": "Cake: Debug Script (.NET Tool)",
+            "description": "test",
+            "body": {
+              "name": "Cake: Debug Script (.NET Tool)",
+              "type": "coreclr",
+              "request": "launch",
+              "program": "dotnet-cake",
+              "windows": {
+                "program": "dotnet-cake.exe"
+              },
+              "args": [
+                "^\"\\${workspaceRoot}/build.cake\"",
+                "--debug",
+                "--verbosity=diagnostic"
+              ],
+              "cwd": "^\"\\${workspaceRoot}\"",
+              "stopAtEntry": true,
+              "externalConsole": false
+            }
+          }
+        ]
+      },
+      {
         "type": "cake-coreclr",
         "label": "Cake CoreCLR",
         "initialConfigurations": [
           {
-            "name": "Cake: Debug Script (CoreCLR)",
+            "name": "Cake: Debug Script (.NET Core)",
             "type": "coreclr",
             "request": "launch",
             "program": "${workspaceRoot}/tools/Cake.CoreCLR/Cake.dll",
@@ -535,7 +581,7 @@
         ],
         "configurationSnippets": [
           {
-            "label": "Cake: Debug Script (CoreCLR)",
+            "label": "Cake: Debug Script (.NET Core)",
             "description": "test",
             "body": {
               "name": "Cake: Debug Script (CoreCLR)",
@@ -559,7 +605,7 @@
         "label": "Cake Mono",
         "initialConfigurations": [
           {
-            "name": "Cake: Debug Script (mono)",
+            "name": "Cake: Debug Script (Mono)",
             "type": "mono",
             "request": "launch",
             "program": "${workspaceRoot}/tools/Cake/Cake.exe",

--- a/package.json
+++ b/package.json
@@ -295,10 +295,7 @@
               "verbosity": "normal",
               "debugType": "coreclr",
               "request": "launch",
-              "program": "~/.dotnet/tools/dotnet-cake",
-              "windows":{
-                "program": "dotnet-cake.exe"
-              },
+              "program": null,
               "cwd": "${workspaceRoot}",
               "stopAtEntry": true,
               "console": "internalConsole",
@@ -361,9 +358,78 @@
                   "default": "launch"
                 },
                 "program": {
-                  "type": "string",
-                  "description": "The executable for the debug session",
-                  "default": "${workspaceRoot}/tools/Cake.CoreCLR/Cake.dll"
+                  "type": [
+                    "null",
+                    "object"
+                  ],
+                  "description": "An Object describing the executable for the debug session. The default of `null` is equal to is equal to {\"default\": \"~/.dotnet/tools/dotnet-cake\", \"win32\": \"dotnet-cake.exe\"}",
+                  "default": null,
+                  "required": [
+                    "default"
+                  ],
+                  "properties": {
+                    "default": {
+                      "type": "string",
+                      "description": "The default executable for the debug session.",
+                      "default": "~/.dotnet/tools/dotnet-cake"
+                    },
+                    "win32": {
+                      "type": [
+                        "null",
+                        "string"
+                      ],
+                      "description": "The win32-specific executable for the debug session.",
+                      "default": "dotnet-cake.exe"
+                    },
+                    "darwin": {
+                      "type": [
+                        "null",
+                        "string"
+                      ],
+                      "description": "The darwin-specific executable for the debug session.",
+                      "default": null
+                    },
+                    "linux": {
+                      "type": [
+                        "null",
+                        "string"
+                      ],
+                      "description": "The linux-specific executable for the debug session.",
+                      "default": null
+                    },
+                    "aix": {
+                      "type": [
+                        "null",
+                        "string"
+                      ],
+                      "description": "The aix-specific executable for the debug session.",
+                      "default": null
+                    },
+                    "freebsd": {
+                      "type": [
+                        "null",
+                        "string"
+                      ],
+                      "description": "The freebsd-specific executable for the debug session.",
+                      "default": null
+                    },
+                    "openbsd": {
+                      "type": [
+                        "null",
+                        "string"
+                      ],
+                      "description": "The openbsd-specific executable for the debug session.",
+                      "default": null
+                    },
+                    "sunos": {
+                      "type": [
+                        "null",
+                        "string"
+                      ],
+                      "description": "The sunos-specific executable for the debug session.",
+                      "default": null
+                    }
+                  }
                 },
                 "cwd": {
                   "type": "string",

--- a/package.json
+++ b/package.json
@@ -295,7 +295,10 @@
               "verbosity": "normal",
               "debugType": "coreclr",
               "request": "launch",
-              "program": "${workspaceRoot}/tools/Cake.CoreCLR/Cake.dll",
+              "program": "~/.dotnet/tools/dotnet-cake",
+              "windows":{
+                "program": "dotnet-cake.exe"
+              },
               "cwd": "${workspaceRoot}",
               "stopAtEntry": true,
               "console": "internalConsole",

--- a/src/cakeMain.ts
+++ b/src/cakeMain.ts
@@ -13,9 +13,8 @@ import { installCakeDebugTaskCommand } from './codeLens/cakeDebugTaskCommand';
 import { CakeCodeLensProvider } from './codeLens/cakeCodeLensProvider';
 import { CakeDocumentSymbolProvider } from './documentSymbols/cakeDocumentSymbolProvider';
 import { TerminalExecutor } from './shared/utils';
-import { getExtensionSettings, ICodeLensSettings, ICodeSymbolsSettings, ITaskRunnerSettings } from './extensionSettings';
+import { getExtensionSettings, getPlatformSettingsValue, ICodeLensSettings, ICodeSymbolsSettings, ITaskRunnerSettings } from './extensionSettings';
 import * as fs from 'fs';
-import * as os from 'os';
 import * as path from 'path';
 
 let taskProvider: vscode.Disposable | undefined;
@@ -168,7 +167,7 @@ async function _getCakeScriptsAsTasks(): Promise<vscode.Task[]> {
                 taskNames.push(matches[1]);
             }
 
-            const buildCommandBase = config.launchCommand[os.platform()] || config.launchCommand.default;
+            const buildCommandBase = getPlatformSettingsValue(config.launchCommand);
             let taskNamePrefix = "";
             if(addFileName){
                 taskNamePrefix = path.basename(file.fsPath) + ": ";

--- a/src/cakeMain.ts
+++ b/src/cakeMain.ts
@@ -221,10 +221,13 @@ function _registerCodeLens(
             'cake.debugTask',
             async (taskName: string, fileName: string) => {
 
+                /*
+                TODO: Should we install something auto-magically?
                 const result = await installCakeDebugCommand(true);
 
                 if(!result)
                     return;
+                */
 
                 installCakeDebugTaskCommand(
                     taskName,

--- a/src/codeLens/cakeDebugTask.ts
+++ b/src/codeLens/cakeDebugTask.ts
@@ -5,6 +5,7 @@ import {
     DebugConfiguration
 } from 'vscode';
 import { ensureNotDirty } from './editorTools';
+import { getPlatformSettingsValue, ICodeLensDebugTaskSettings } from '../extensionSettings';
 
 export class CakeDebugTask {
     constructor() {}
@@ -12,18 +13,20 @@ export class CakeDebugTask {
     private _getDebuggerConfig(
         taskName: string,
         fileName: string,
-        debugConfig: any
+        debugConfig: ICodeLensDebugTaskSettings
     ): Promise<DebugConfiguration> {
         return new Promise((resolve, reject) => {
             if (!taskName) {
                 reject('Not a valid Cake task');
             }
 
+            const program = getPlatformSettingsValue(debugConfig.program);
+
             const debuggerConfig: DebugConfiguration = {
                 name: 'Cake: Task Debug Script',
                 type: debugConfig.debugType,
                 request: debugConfig.request,
-                program: debugConfig.program,
+                program: program,
                 args: [
                     `${fileName}`,
                     `--target=${taskName}`,
@@ -36,13 +39,6 @@ export class CakeDebugTask {
                 logging: debugConfig.logging
             };
 
-            // https://code.visualstudio.com/docs/editor/tasks#_operating-system-specific-properties
-            ["windows", "linux", "osx"].forEach(platform => {
-                const platformSettings = debugConfig[platform];
-                if(platformSettings){
-                    debuggerConfig[platform] = platformSettings;
-                }    
-            });
             resolve(debuggerConfig);
         });
     }

--- a/src/codeLens/cakeDebugTask.ts
+++ b/src/codeLens/cakeDebugTask.ts
@@ -20,13 +20,13 @@ export class CakeDebugTask {
             }
 
             const debuggerConfig: DebugConfiguration = {
-                name: 'Cake: Task Debug Script (CoreCLR)',
+                name: 'Cake: Task Debug Script',
                 type: debugConfig.debugType,
                 request: debugConfig.request,
                 program: debugConfig.program,
                 args: [
                     `${fileName}`,
-                    `--target=\"${taskName}\"`,
+                    `--target=${taskName}`,
                     '--debug',
                     `--verbosity=${debugConfig.verbosity}`
                 ],
@@ -35,6 +35,14 @@ export class CakeDebugTask {
                 console: debugConfig.console,
                 logging: debugConfig.logging
             };
+
+            // https://code.visualstudio.com/docs/editor/tasks#_operating-system-specific-properties
+            ["windows", "linux", "osx"].forEach(platform => {
+                const platformSettings = debugConfig[platform];
+                if(platformSettings){
+                    debuggerConfig[platform] = platformSettings;
+                }    
+            });
             resolve(debuggerConfig);
         });
     }

--- a/src/codeLens/cakeRunTaskCommand.ts
+++ b/src/codeLens/cakeRunTaskCommand.ts
@@ -1,6 +1,5 @@
-import * as os from 'os';
 import { window } from 'vscode';
-import { IExtensionSettings } from '../extensionSettings';
+import { getPlatformSettingsValue, IExtensionSettings } from '../extensionSettings';
 import { TerminalExecutor } from '../shared/utils';
 import { ensureNotDirty } from './editorTools';
 
@@ -13,7 +12,7 @@ export async function installCakeRunTaskCommand(
         window.showInformationMessage("Saved file before running task...");
     }
 
-    let buildCommand = settings.taskRunner.launchCommand[os.platform()] || settings.taskRunner.launchCommand.default;
+    let buildCommand = getPlatformSettingsValue(settings.taskRunner.launchCommand);
     buildCommand = `${buildCommand} \"${fileName}\" --target=\"${taskName}\" --verbosity=${settings.taskRunner.verbosity}`;
 
     TerminalExecutor.runInTerminal(buildCommand);

--- a/src/debug/cakeTool.ts
+++ b/src/debug/cakeTool.ts
@@ -1,0 +1,40 @@
+import { spawn } from 'child_process';
+
+export class CakeTool {
+    
+    public isInstalled(): Thenable<boolean> {
+        return new Promise((resolve, reject) => {
+            // TODO: Do we need to check the version?! Update it?!
+            const proc = spawn('dotnet', ['tool', 'list', '--global']);
+            let found = false;
+            
+            proc.on('error', (error) => {
+                reject(error);
+            });
+
+            proc.stdout.on('data', (data: Buffer) => {
+                if(found) { return; }
+                const txt = data.toString();
+                found = txt.toLowerCase().indexOf('cake.tool') > -1;
+            });
+
+            proc.on('close', () => {
+                resolve(found);
+            });
+        });
+    }
+
+    public install(): Thenable<boolean> {
+        return new Promise((resolve, reject) => {
+            const proc = spawn('dotnet', ['tool', 'install', 'Cake.Tool', '--global']);
+            
+            proc.on('error', (error) => {
+                reject(error);
+            });
+
+            proc.on('close', () => {
+                resolve(true);
+            });
+        });
+    }
+}

--- a/src/install/actions/installCake.ts
+++ b/src/install/actions/installCake.ts
@@ -70,11 +70,12 @@ export function installCake(
                     })
                 );
             }
+            // TODO: Is a selection CoreCLR/global tool needed?
             if (installOpts.installDebug) {
                 results.push(
                     installCakeDebug().then(v => {
                         logResult(
-                            v,
+                            v.installed,
                             'Debug dependencies successfully installed.',
                             'Error encountered while install debugging dependencies.'
                         );


### PR DESCRIPTION
@gep13 I did two things different to what you did in the video:
* I removed the `windows` property from settings and added an object with `default` and `win32` like I've done with the launchCommand.
* I fixed the reason debugging did not work during the video: I removed the quotes (`"`) from the target. Not sure why this is a problem but debugging does not work (any longer) when they are present.
