### PR TITLE
(GH-32) added a simple problemMatcher

### DIFF
--- a/package.json
+++ b/package.json
@@ -371,6 +371,22 @@
           }
         }
       }
+    ],
+    "problemMatchers": [
+      {
+        "name": "cake",
+        "owner": "cake",
+        "fileLocation": ["absolute"],
+        "pattern": {
+            "regexp": "^(.+)\\((\\d+),(\\d+)\\): (error|warning) (\\w+): (.*)$",
+            "file": 1,
+            "line": 2,
+            "column": 3,
+            "severity": 4,
+            "code": 5,
+            "message": 6
+          }
+      }
     ]
   },
   "scripts": {


### PR DESCRIPTION
for errors during script compilation.
(Not for errors during script execution, though)

fixes #32 

Using this `problemMatcher` an output in the console that looks like this:
```
❯ .\build.ps1 -Script .\bob.cake
Preparing to run build script...
Running build script...
D:/_dev/test-123/bill.cake(22,24): error CS1002: ; expected
D:/_dev/test-123/bob.cake(6,5): error CS0102: The type 'Submission#0' already contains a definition for 'target'
D:/_dev/test-123/bob.cake(7,5): error CS0102: The type 'Submission#0' already contains a definition for 'configuration'
D:/_dev/test-123/bob.cake(30,11): error CS0229: Ambiguity between 'target' and 'target'
Error: Error(s) occurred when compiling build script:
D:/_dev/test-123/bill.cake(22,24): error CS1002: ; expected
D:/_dev/test-123/bob.cake(6,5): error CS0102: The type 'Submission#0' already contains a definition for 'target'
D:/_dev/test-123/bob.cake(7,5): error CS0102: The type 'Submission#0' already contains a definition for 'configuration'
D:/_dev/test-123/bob.cake(30,11): error CS0229: Ambiguity between 'target' and 'target'
```

will produce problems like this:
![image](https://user-images.githubusercontent.com/349188/99120347-053f8500-25fb-11eb-8f17-075bcb2a40d0.png)
