### PR TITLE
(GH-99) Simple support for codeSymbols

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,6 +106,15 @@ There are a number of configuration options which allow you to control the Cake 
 **Remark**: While the command to debug a task is configurable using the `cake.codeLens.debugTask.program` setting,
 there is no specific setting for configuring the command to run a task. For this case the `cake.taskRunner.launchCommand` setting is used (see above).  In addition, the verbosity used with running a task is controlled via the `cake.taskRunner.verbosity` setting.
 
+### CodeSymbols
+
+The extension produces "code symbols", which are in turn used by Visual Studio Code to produce the code outline and breadcrumb navigation.
+
+There are configuration options to allow you to configure the symbol generation:
+
+* `cake.codeSymbols.contextRegularExpression`: a regular expression pattern to get contexts from Cake script. Default value is `(Setup|TaskSetup|Teardown|TaskTeardown|RunTarget)\\s*?`.
+* `cake.codeSymbols.taskRegularExpression`: a regular expression pattern to get tasks from Cake script. Default value is `(Task\\s*?\\(\\s*?\"(.*?)\"\\s*?\\)|Setup\\(.*=>|TearDown\\(.*=>|RunTarget\\(.*\\);)`.
+
 ## Resource Video
 
 There is a short introduction video to the Visual Studio Code Extension for Cake here:

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "theme": "light"
   },
   "engines": {
-    "vscode": "^1.24.0"
+    "vscode": "^1.25.0"
   },
   "categories": [
     "Programming Languages",
@@ -419,6 +419,33 @@
                   }
                 }
               }
+            }
+          }
+        },
+        "cake.codeOutline": {
+          "type": "object",
+          "description": "The Cake outline view configuration",
+          "default": {
+            "showCodeOutline": true,
+            "scriptsIncludePattern": "**/*.cake",
+            "contextRegularExpression": "(Setup|TaskSetup|Teardown|TaskTeardown|RunTarget)\\s*?",
+            "taskRegularExpression": "Task\\s*?\\(\\s*?\"(.*?)\"\\s*?\\)"
+          },
+          "properties": {
+            "showCodeOutline": {
+              "type": "boolean",
+              "description": "Show code outline for tasks in Cake files",
+              "default": true
+            },
+            "scriptsIncludePattern": {
+              "type": "string",
+              "description": "Glob pattern to detect cake build scripts in current workspace",
+              "default": "**/*.cake"
+            },
+            "taskRegularExpression": {
+              "type": "string",
+              "description": "Regular expression pattern to get tasks from Cake script",
+              "default": "(Task\\s*?\\(\\s*?\"(.*?)\"\\s*?\\)|Setup\\(.*=>|TearDown\\(.*=>|RunTarget\\(.*\\);)"
             }
           }
         }

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "theme": "light"
   },
   "engines": {
-    "vscode": "^1.25.0"
+    "vscode": "^1.24.0"
   },
   "categories": [
     "Programming Languages",
@@ -422,25 +422,18 @@
             }
           }
         },
-        "cake.codeOutline": {
+        "cake.codeSymbols": {
           "type": "object",
-          "description": "The Cake outline view configuration",
+          "description": "The Cake code symbols configuration",
           "default": {
-            "showCodeOutline": true,
-            "scriptsIncludePattern": "**/*.cake",
             "contextRegularExpression": "(Setup|TaskSetup|Teardown|TaskTeardown|RunTarget)\\s*?",
             "taskRegularExpression": "Task\\s*?\\(\\s*?\"(.*?)\"\\s*?\\)"
           },
           "properties": {
-            "showCodeOutline": {
-              "type": "boolean",
-              "description": "Show code outline for tasks in Cake files",
-              "default": true
-            },
-            "scriptsIncludePattern": {
+            "contextRegularExpression":  {
               "type": "string",
-              "description": "Glob pattern to detect cake build scripts in current workspace",
-              "default": "**/*.cake"
+              "description": "Regular expression pattern to get contexts from Cake script",
+              "default": "(Setup|TaskSetup|Teardown|TaskTeardown|RunTarget)\\s*?"
             },
             "taskRegularExpression": {
               "type": "string",

--- a/src/cakeMain.ts
+++ b/src/cakeMain.ts
@@ -11,6 +11,7 @@ import { installCakeBakeryCommand } from './bakery/cakeBakeryCommand';
 import { installCakeRunTaskCommand } from './codeLens/cakeRunTaskCommand';
 import { installCakeDebugTaskCommand } from './codeLens/cakeDebugTaskCommand';
 import { CakeCodeLensProvider } from './codeLens/cakeCodeLensProvider';
+import { CakeDocumentSymbolProvider} from './documentSymbols/cakeDocumentSymbolProvider';
 import { TerminalExecutor } from './shared/utils';
 import { getExtensionSettings, ICodeLensSettings, ITaskRunnerSettings } from './extensionSettings';
 import * as fs from 'fs';
@@ -19,6 +20,7 @@ import * as path from 'path';
 
 let taskProvider: vscode.Disposable | undefined;
 let codeLensProvider: CakeCodeLensProvider;
+let documentSymbolProvider: CakeDocumentSymbolProvider;
 
 interface CakeTaskDefinition extends vscode.TaskDefinition {
     script: string;
@@ -235,6 +237,17 @@ function _registerCodeLens(
                 pattern: config.scriptsIncludePattern
             },
             codeLensProvider
+        )
+    );
+
+    documentSymbolProvider = new CakeDocumentSymbolProvider();
+    context.subscriptions.push(
+        vscode.languages.registerDocumentSymbolProvider(
+            {
+                language: 'csharp',
+                scheme: 'file'
+            }, 
+            documentSymbolProvider
         )
     );
 }

--- a/src/cakeMain.ts
+++ b/src/cakeMain.ts
@@ -11,7 +11,7 @@ import { installCakeBakeryCommand } from './bakery/cakeBakeryCommand';
 import { installCakeRunTaskCommand } from './codeLens/cakeRunTaskCommand';
 import { installCakeDebugTaskCommand } from './codeLens/cakeDebugTaskCommand';
 import { CakeCodeLensProvider } from './codeLens/cakeCodeLensProvider';
-import { CakeDocumentSymbolProvider} from './documentSymbols/cakeDocumentSymbolProvider';
+import { CakeDocumentSymbolProvider } from './documentSymbols/cakeDocumentSymbolProvider';
 import { TerminalExecutor } from './shared/utils';
 import { getExtensionSettings, ICodeLensSettings, ITaskRunnerSettings } from './extensionSettings';
 import * as fs from 'fs';
@@ -93,6 +93,8 @@ export function activate(context: vscode.ExtensionContext): void {
     // Register code lens provider and tasks
     _registerCodeLens(config.codeLens, context);
 
+    _registerCodeOutline(config.codeOutline, context);
+
     vscode.workspace.onDidChangeConfiguration(onConfigurationChanged);
     onConfigurationChanged();
 }
@@ -102,6 +104,7 @@ function onConfigurationChanged() {
 
     _verifyTasksRunner(config.taskRunner);
     _verifyCodeLens(config.codeLens);
+    _verifyCodeOutline(config.codeOutline);
 }
 
 function _verifyTasksRunner(config: ITaskRunnerSettings) {
@@ -239,8 +242,14 @@ function _registerCodeLens(
             codeLensProvider
         )
     );
+}
 
-    documentSymbolProvider = new CakeDocumentSymbolProvider();
+function _registerCodeOutline(
+    config: any,
+    context: vscode.ExtensionContext
+): void {
+
+    documentSymbolProvider = new CakeDocumentSymbolProvider(config);
     context.subscriptions.push(
         vscode.languages.registerDocumentSymbolProvider(
             {
@@ -250,6 +259,10 @@ function _registerCodeLens(
             documentSymbolProvider
         )
     );
+}
+
+function _verifyCodeOutline(config: any): void {
+    documentSymbolProvider.showCodeOutline = config.showCodeOutline;
 }
 
 function _verifyCodeLens(config: ICodeLensSettings): void {

--- a/src/documentSymbols/cakeDocumentSymbolProvider.ts
+++ b/src/documentSymbols/cakeDocumentSymbolProvider.ts
@@ -1,0 +1,41 @@
+'use strict';
+
+import { DocumentSymbolProvider, TextDocument, CancellationToken, SymbolInformation, SymbolKind, Location } from 'vscode';
+
+export class CakeDocumentSymbolProvider implements DocumentSymbolProvider {
+
+    public provideDocumentSymbols(document: TextDocument, token: CancellationToken): Promise<SymbolInformation[]> {
+        
+        return new Promise((resolve, reject) => {
+            const symbols: SymbolInformation[] = [];
+
+            if (!document) {
+                return reject('No open document in the workspace');
+            }
+
+            if (token.isCancellationRequested) {
+                return resolve(symbols);
+            }    
+            
+            for (var i = 0; i < document.lineCount; i++) {
+                const line = document.lineAt(i)
+                const match = this.matchFunction(line.text);
+                if (match !== null) {
+                    symbols.push(new SymbolInformation(
+                        match[1],
+                        SymbolKind.Function,
+                        "TaskContainer",
+                        new Location(document.uri, line.range)
+                    ));
+                }
+            }
+
+            resolve(symbols);
+        });
+    }
+
+    public matchFunction(line: string) {
+        const function_regex = "Task\\s*?\\(\\s*?\"(.*?)\"\\s*?\\)"
+        return line.match(function_regex)
+    }
+}

--- a/src/documentSymbols/cakeDocumentSymbolProvider.ts
+++ b/src/documentSymbols/cakeDocumentSymbolProvider.ts
@@ -8,14 +8,17 @@ import {
     DocumentSymbol,
     Range
 } from 'vscode';
+import { ICodeSymbolsSettings } from '../extensionSettings'
 
 export class CakeDocumentSymbolProvider implements DocumentSymbolProvider {
-    private ctxRegEx: RegExp;
-    private taskRegEx: RegExp;
-    public showCodeOutline: boolean = false; 
-
+    private ctxRegEx!: RegExp;
+    private taskRegEx!: RegExp;
     
-    public constructor(config:any) {
+    public constructor(config: ICodeSymbolsSettings) {
+        this.reconfigure(config);
+    }
+
+    public reconfigure(config: ICodeSymbolsSettings){
         this.ctxRegEx = new RegExp(config.contextRegularExpression, 'gm');
         this.taskRegEx = new RegExp(config.taskRegularExpression, 'gm');
     }
@@ -32,12 +35,12 @@ export class CakeDocumentSymbolProvider implements DocumentSymbolProvider {
             if (!document) {
                 return reject('No open document in the workspace');
             }
-
-            if (token.isCancellationRequested) {
-                return resolve(symbols);
-            }    
-            
+ 
             for (var i = 0; i < document.lineCount; i++) {
+                if (token.isCancellationRequested) {
+                    return resolve(symbols);
+                }  
+                
                 const line = document.lineAt(i)
                 let match = this.matchTask(line.text);
                 if (match !== null) {

--- a/src/extensionSettings.ts
+++ b/src/extensionSettings.ts
@@ -51,11 +51,17 @@ export interface ICodeLensSettings {
     debugTask: ICodeLensDebugTaskSettings;
 }
 
+export interface ICodeSymbolsSettings {
+    contextRegularExpression: string;
+    taskRegularExpression: string;
+}
+
 export interface IExtensionSettings {
     taskRunner: ITaskRunnerSettings;
     bootstrappers: IBootstrappersSettings;
     configuration: IConfigurationSettings;
     codeLens: ICodeLensSettings;
+    codeSymbols: ICodeSymbolsSettings;
 }
 
 export function getExtensionSettings(): IExtensionSettings {


### PR DESCRIPTION
This is a rebased version of #101. Therefore, #101 is superseded by this PR.

In addition to the code provided by @Tdue21 I only added small modifications that were necessary due to the modified codebase and some documentation.

I also made three significant changes: 
* I renamed everything form `codeOutline` to `symbolProvider` to more accurately represent what is being done instead of what is the intended outcome.
* I removed the `showCodeOutline` option, as it wasn't used.
* I moved the test for cancelation (i.e. `cancellationToken.isCancellationRequested`) from once at the start to inside the `for` loop, as that is the long-running part.