### PR TITLE
(GH-461) `launchCommand` now defaults to .NET Tool

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,7 +78,7 @@ There are a number of configuration options which allow you to control how the T
 * `cake.taskRunner.taskRegularExpression`: a regular expression pattern which is used to identify Tasks within the `*.cake` files. Default value is `Task\\s*?\\(\\s*?\"(.*?)\"\\s*?\\)`.
 * `cake.taskRunner.launchCommand`: the name of the build script to run, when running a task.
   This is a complex object, consisting of at least one property `default` and optionally properties corresponding to values of [`os.platform()`](https://nodejs.org/api/os.html#os_os_platform) for non-default values specific to different platforms.
-  Default value is `null` which is equal to specifying `{"default": "./build.sh", "win32": "powershell -ExecutionPolicy ByPass -File build.ps1"}`.
+  Default value is `null` which is equal to specifying `{"default": "~/.dotnet/tools/dotnet-cake", "win32": "dotnet-cake.exe"}`.
 * `cake.taskRunner.verbosity`: allows you to control cake `run task` verbosity (`diagnostic`, `minimal`, `normal`, `quiet` and `verbose`. Default value is `normal`.
 
 ### Codelens

--- a/package.json
+++ b/package.json
@@ -136,7 +136,7 @@
                 "null",
                 "object"
               ],
-              "description": "The name of the build script to run, when running a task. the default of `null` is equal to {\"default\": \"./build.sh\", \"win32\": \"powershell -ExecutionPolicy ByPass -File build.ps1\"}",
+              "description": "The name of the build script to run, when running a task. the default of `null` is equal to {\"default\": \"~/.dotnet/tools/dotnet-cake\", \"win32\": \"dotnet-cake.exe\"}",
               "default": null,
               "required": [
                 "default"
@@ -145,7 +145,7 @@
                 "default": {
                   "type": "string",
                   "description": "The default name of the build script to run.",
-                  "default": "./build.sh"
+                  "default": "~/.dotnet/tools/dotnet-cake"
                 },
                 "win32": {
                   "type": [
@@ -153,7 +153,7 @@
                     "string"
                   ],
                   "description": "The win32-specific name of the build script to run.",
-                  "default": "powershell -ExecutionPolicy ByPass -File build.ps1"
+                  "default": "dotnet-cake.exe"
                 },
                 "darwin": {
                   "type": [

--- a/src/extensionSettings.ts
+++ b/src/extensionSettings.ts
@@ -109,8 +109,8 @@ export function getExtensionSettings(): IExtensionSettings {
 
 function _ensureDefaultsOnLaunchCommand(launchCommand: ILaunchCommandSettings): ILaunchCommandSettings {
     const defaultVal = {
-        default: "./build.sh",
-        win32: "powershell -ExecutionPolicy ByPass -File build.ps1"
+        default: "~/.dotnet/tools/dotnet-cake",
+        win32: "dotnet-cake.exe"
     };
 
     return _ensureDefaultsOnPlatformSetting(launchCommand, defaultVal);


### PR DESCRIPTION
fixes #461 