### PR TITLE
(GH-460) implemented updating of the Cake.Tool

### DIFF
--- a/src/cakeMain.ts
+++ b/src/cakeMain.ts
@@ -62,7 +62,7 @@ export function activate(context: vscode.ExtensionContext): void {
     // Register the debug command.
     context.subscriptions.push(
         vscode.commands.registerCommand('cake.debug', async () => {
-            installCakeDebugCommand();
+            installCakeDebugCommand(context);
         })
     );
     // Register the build file command.
@@ -211,7 +211,8 @@ function _registerCodeLens(
                 installCakeRunTaskCommand(
                     taskName,
                     fileName,
-                    getExtensionSettings()
+                    getExtensionSettings(),
+                    context
                 );
             }
         )
@@ -232,7 +233,8 @@ function _registerCodeLens(
                 installCakeDebugTaskCommand(
                     taskName,
                     fileName,
-                    getExtensionSettings()
+                    getExtensionSettings(),
+                    context
                 );
             }
         )

--- a/src/codeLens/cakeDebugTask.ts
+++ b/src/codeLens/cakeDebugTask.ts
@@ -2,13 +2,14 @@ import {
     window,
     debug,
     workspace,
-    DebugConfiguration
+    DebugConfiguration,
+    ExtensionContext
 } from 'vscode';
 import { ensureNotDirty, installCakeToolIfNeeded } from './shared';
 import { getPlatformSettingsValue, ICodeLensDebugTaskSettings, IExtensionSettings } from '../extensionSettings';
 
 export class CakeDebugTask {
-    constructor() {}
+    constructor(private context: ExtensionContext) {}
 
     private _getDebuggerConfig(
         taskName: string,
@@ -54,7 +55,7 @@ export class CakeDebugTask {
             }
             
             await ensureNotDirty(fileName);
-            await installCakeToolIfNeeded(settings);
+            await installCakeToolIfNeeded(settings, this.context);
         
             const workspaceFolder = workspace.workspaceFolders[0];
             const debuggerConfig = await this._getDebuggerConfig(taskName, fileName, debugConfig);

--- a/src/codeLens/cakeDebugTaskCommand.ts
+++ b/src/codeLens/cakeDebugTaskCommand.ts
@@ -1,11 +1,13 @@
+import { ExtensionContext } from 'vscode';
 import { IExtensionSettings } from '../extensionSettings';
 import { CakeDebugTask } from './cakeDebugTask';
 
 export async function installCakeDebugTaskCommand(
     taskName: string,
     fileName: string,
-    debugConfig: IExtensionSettings
+    debugConfig: IExtensionSettings,
+    context: ExtensionContext
 ) {
-    const debugTask = new CakeDebugTask();
+    const debugTask = new CakeDebugTask(context);
     debugTask.debug(taskName, fileName, debugConfig);
 }

--- a/src/codeLens/cakeRunTaskCommand.ts
+++ b/src/codeLens/cakeRunTaskCommand.ts
@@ -1,3 +1,4 @@
+import { ExtensionContext } from 'vscode';
 import { getPlatformSettingsValue, IExtensionSettings } from '../extensionSettings';
 import { TerminalExecutor } from '../shared/utils';
 import { ensureNotDirty, installCakeToolIfNeeded } from './shared';
@@ -5,10 +6,11 @@ import { ensureNotDirty, installCakeToolIfNeeded } from './shared';
 export async function installCakeRunTaskCommand(
     taskName: string,
     fileName: string,
-    settings: IExtensionSettings
+    settings: IExtensionSettings,
+    context: ExtensionContext
 ) {
     await ensureNotDirty(fileName);
-    await installCakeToolIfNeeded(settings);
+    await installCakeToolIfNeeded(settings, context);
     
     let buildCommand = getPlatformSettingsValue(settings.taskRunner.launchCommand);
     buildCommand = `${buildCommand} \"${fileName}\" --target=\"${taskName}\" --verbosity=${settings.taskRunner.verbosity}`;

--- a/src/codeLens/shared.ts
+++ b/src/codeLens/shared.ts
@@ -24,15 +24,12 @@ export async function ensureNotDirty(fileName: string) : Promise<void> {
 export async function installCakeToolIfNeeded(settings: IExtensionSettings) {
     if(settings.codeLens.installNetTool) {
         const cakeTool = new CakeTool();
-        const isInstalled = await cakeTool.isInstalled();
-        if(!isInstalled){
-            try {
-                await cakeTool.install();
-            }
-            catch (ex) {
-                logError("Error installing Cake .NET Tool", true);
-                logError(ex);
-            }
+        try {
+            await cakeTool.ensureInstalled();
+        }
+        catch (ex) {
+            logError("Error installing Cake .NET Tool", true);
+            logError(ex);
         }
     }
 }

--- a/src/codeLens/shared.ts
+++ b/src/codeLens/shared.ts
@@ -1,4 +1,4 @@
-import { workspace } from 'vscode';
+import { ExtensionContext, workspace } from 'vscode';
 import { CakeTool } from '../debug/cakeTool';
 import { IExtensionSettings } from '../extensionSettings';
 import { logError, logInfo } from '../shared/log';
@@ -21,9 +21,9 @@ export async function ensureNotDirty(fileName: string) : Promise<void> {
     logInfo("Saved file before running task...", true);
 }
 
-export async function installCakeToolIfNeeded(settings: IExtensionSettings) {
+export async function installCakeToolIfNeeded(settings: IExtensionSettings, context: ExtensionContext) {
     if(settings.codeLens.installNetTool) {
-        const cakeTool = new CakeTool();
+        const cakeTool = new CakeTool(context);
         try {
             await cakeTool.ensureInstalled();
         }

--- a/src/debug/cakeDebugCommand.ts
+++ b/src/debug/cakeDebugCommand.ts
@@ -1,9 +1,9 @@
-import { window, workspace } from 'vscode';
+import { ExtensionContext, window, workspace } from 'vscode';
 import * as fs from 'fs';
 import { CakeDebug } from './cakeDebug';
 import { CakeTool } from './cakeTool';
 
-export async function installCakeDebugCommand(hideWarning?: boolean): Promise<boolean> {
+export async function installCakeDebugCommand(context: ExtensionContext, hideWarning?: boolean): Promise<boolean> {
     // Check if there is an open folder in workspace
     if (workspace.rootPath === undefined) {
         window.showErrorMessage('You have not yet opened a folder.');
@@ -20,7 +20,7 @@ export async function installCakeDebugCommand(hideWarning?: boolean): Promise<bo
     }
 
     const isCakeTool = selection === 'Cake.Tool';
-    const result = await (isCakeTool ? installCakeTool()  : installCakeDebug());
+    const result = await (isCakeTool ? installCakeTool(context)  : installCakeDebug());
     const messages = {
         advice: isCakeTool ?
             'Cake Debug Dependencies correctly installed globally.' :
@@ -64,8 +64,8 @@ export async function installCakeDebug(): Promise<IInstallResult> {
     return { installed: result, advice: true };
 }
 
-async function installCakeTool(): Promise<IInstallResult> {
-    const tool = new CakeTool();
+async function installCakeTool(context: ExtensionContext): Promise<IInstallResult> {
+    const tool = new CakeTool(context);
     const installationModified = await tool.ensureInstalled();
     return { installed: true, advice: installationModified };
 }

--- a/src/debug/cakeDebugCommand.ts
+++ b/src/debug/cakeDebugCommand.ts
@@ -66,12 +66,6 @@ export async function installCakeDebug(): Promise<IInstallResult> {
 
 async function installCakeTool(): Promise<IInstallResult> {
     const tool = new CakeTool();
-
-    const alreadyInstalled = await tool.isInstalled();
-    if(alreadyInstalled){
-        return { installed: true, advice: false };
-    }
-
-    const result = await tool.install();
-    return { installed: result, advice: true };
+    const installationModified = await tool.ensureInstalled();
+    return { installed: true, advice: installationModified };
 }

--- a/src/debug/cakeTool.ts
+++ b/src/debug/cakeTool.ts
@@ -1,29 +1,49 @@
-import { spawn } from 'child_process';
+import { ChildProcessWithoutNullStreams, spawn } from 'child_process';
+import { window } from 'vscode';
+import { Version } from '../shared/version';
 
 export class CakeTool {
-    
-    public isInstalled(): Thenable<boolean> {
+
+    private getCakeVersionFromProc(proc: ChildProcessWithoutNullStreams): Promise<Version|null> {
         return new Promise((resolve, reject) => {
-            // TODO: Do we need to check the version?! Update it?!
-            const proc = spawn('dotnet', ['tool', 'list', '--global']);
-            let found = false;
-            
+            const regex = new RegExp(/^cake\.tool\s+([\d\.]+(-\S+)?)/im); // https://regex101.com/r/nC8uxu/2
+            let ver: Version|null = null;
             proc.on('error', (error) => {
                 reject(error);
             });
 
             proc.stdout.on('data', (data: Buffer) => {
-                if(found) { return; }
+                if(ver !== null){
+                    return;
+                }
                 const txt = data.toString();
-                found = txt.toLowerCase().indexOf('cake.tool') > -1;
+                const match = regex.exec(txt);
+                if(match) {
+                    ver = Version.parse(match[1])
+                }
             });
 
             proc.on('close', () => {
-                resolve(found);
+                resolve(ver);
             });
         });
     }
 
+    public async getAvailableVersion(): Promise<Version|null> {
+        const proc = spawn('dotnet', ['tool', 'search', 'cake.tool']);
+        const ver = await this.getCakeVersionFromProc(proc);
+        return ver;
+    }
+
+    /**
+     * returns the currently installed version, or null if no version is installed.
+     */
+    public async getInstalledVersion(): Promise<Version|null> {
+        const proc = spawn('dotnet', ['tool', 'list', '--global']);
+        const ver = await this.getCakeVersionFromProc(proc);
+        return ver;
+    }
+    
     public install(): Thenable<boolean> {
         return new Promise((resolve, reject) => {
             const proc = spawn('dotnet', ['tool', 'install', 'Cake.Tool', '--global']);
@@ -36,5 +56,56 @@ export class CakeTool {
                 resolve(true);
             });
         });
+    }
+
+    public update(): Thenable<boolean> {
+        return new Promise((resolve, reject) => {
+            const proc = spawn('dotnet', ['tool', 'update', 'Cake.Tool', '--global']);
+            
+            proc.on('error', (error) => {
+                reject(error);
+            });
+
+            proc.on('close', () => {
+                resolve(true);
+            });
+        });
+    }
+
+    /**
+     * ensures Cake.Tool is installed,
+     * asking for an update, if a newer version is available.
+     * @returns `true`, if Cake.Tool was actively installed or updated. `false` if Cake.Tool was already installed and up-to-date.
+     */
+    public async ensureInstalled(): Promise<boolean> {
+        const installedVersion = await this.getInstalledVersion();
+
+        if(installedVersion === null) {
+            await this.install();
+            return true;
+        }
+    
+        const availableVersion = await this.getAvailableVersion();
+        if(availableVersion === null) {
+            // cake.tool is installed, but we were unable to detect if it's the newest version
+            // probably ok..
+            return false;
+        }
+    
+        if(installedVersion.greaterThan(availableVersion, true)) {
+            return false;
+        }
+    
+        // ask for updates
+        const selection = await window.showQuickPick(['Yes','No'], {
+            placeHolder: `Cake.Tool version ${availableVersion.toString()} is available. Update now?`
+        });
+    
+        if(selection !== 'Yes') {
+            return false;
+        }
+    
+        await this.update();
+        return true;
     }
 }

--- a/src/shared/version.ts
+++ b/src/shared/version.ts
@@ -1,0 +1,186 @@
+/**
+ * represents a version that can be compared to other versions.
+ */
+export class Version {
+
+    private parts: number[] = [];
+    private suffixTxt: string|null = null;
+    private suffix: number|null = null;
+    private static readonly suffixMatcher = new RegExp(/-(\D+)(\d+)/); // https://regex101.com/r/nrjWum/1
+
+    constructor(...parts: number[]) {
+        this.parts = parts;        
+    }
+
+    /**
+     * parses a version string into a @see Version.
+     * @param text the sting to parse.
+     */
+    public static parse(text: string): Version {
+        if(!text){
+            throw new Error("text can not be empty.");
+        }
+
+        let suffixText:string|null = null;
+        let suffix = 0;
+        const suffixMatch = this.suffixMatcher.exec(text);
+        if(suffixMatch) {
+            suffixText = suffixMatch[1];
+            suffix = Number.parseInt(suffixMatch[2], 10);
+        }
+
+        const txtParts = text.split("-", 2)[0].split(".");
+        const parts = txtParts.map((x) => {
+            const num = Number.parseInt(x, 10);
+            if(Number.isNaN(num)){
+                throw new Error(`could not parse ${x} as part of a version.`);
+            }
+
+            if(num.toString(10) !== x){
+                throw new Error(`error parsing: ${x} was parsed as ${num}.`);
+            }
+
+            return num;
+        });
+
+        const ver = new Version(...parts);
+
+        if(suffixText !== null) {
+            ver.suffixTxt = suffixText;
+            ver.suffix = suffix;
+        }
+
+        return ver;
+    }
+
+    /**
+     * @override 
+     */
+    public toString(): string {
+        let s = this.parts.join(".");
+        if(this.suffixTxt != null){
+            s += "-"+this.suffixTxt+this.suffix;
+        }
+
+        return s;
+    }
+
+    /**
+     * tests the other version for equality with this version.
+     * @param other the version to compare with.
+     */
+    public equalTo(other: Version): boolean {
+        if(!other){
+            return false;
+        }
+
+        const count = Math.max(this.partCount, other.partCount);
+
+        for(let i=0; i<count; i++) {
+            const left = this.getPart(i);
+            const right = other.getPart(i);
+
+            if(left !== right) {
+                return false;
+            }
+        }
+
+        return true;
+    }
+
+    /**
+     * tests if this version is greater/greaterEqual than the other version.
+     * @param other 
+     */
+    public greaterThan(other: Version, orEqual=false): boolean {
+        if(!other){
+            return false;
+        }
+
+        const count = Math.max(this.partCount, other.partCount);
+
+        for(let i=0; i<count; i++) {
+            const left = this.getPart(i);
+            const right = other.getPart(i);
+
+            if(left > right) {
+                return true;
+            }
+            if(left < right) {
+                return false;
+            }
+        }
+
+        return orEqual;
+    }
+
+    /**
+     * tests if this version is less/lessEqual than the other version.
+     * @param other 
+     */
+    public lessThan(other: Version, orEqual=false): boolean {
+        if(!other){
+            return false;
+        }
+
+        const count = Math.max(this.partCount, other.partCount);
+
+        for(let i=0; i<count; i++) {
+            const left = this.getPart(i);
+            const right = other.getPart(i);
+
+            if(left < right) {
+                return true;
+            }
+            if(left > right) {
+                return false;
+            }
+        }
+
+        return orEqual;
+    }
+
+    /**
+     * returns the n-th part of the version, counted from left, starting at 0.
+     * (so "major" would be 0, "minor" would be 1).
+     * @param i the part-number of the version, or 0 if the part does not exist.
+     */
+    public getPart(i: number){
+        if(i<this.parts.length){
+            return this.parts[i];
+        }
+        if(i==this.parts.length && this.suffix != null){
+            return this.suffix;
+        }
+
+        return 0;
+    }
+
+    /**
+     * gets the count of the parts of this version.
+     */
+    public get partCount(): number {
+        return this.parts.length + (this.suffix === null ? 0 : 1);
+    }
+
+    /**
+     * returns the major version number. Equal to calling `getPart(0)`.
+     */
+    public get major(): number {
+       return this.getPart(0);
+    }
+
+    /**
+     * returns the minor version number. Equal to calling `getPart(1)`.
+     */
+    public get minor(): number {
+        return this.getPart(1);
+    }
+
+    /**
+     * returns the patch version number. Equal to calling `getPart(2)`.
+     */
+    public get patch(): number {
+        return this.getPart(2);
+    }
+}

--- a/test/shared/shared.test.ts
+++ b/test/shared/shared.test.ts
@@ -1,7 +1,9 @@
 import describeUtilsTests from './utils/utils.test';
+import describeVersionTests from './version.test';
 
 export default function describeSharedTests() {
     suite('Shared', function() {
         describeUtilsTests();
+        describeVersionTests();
     });
 }

--- a/test/shared/version.test.ts
+++ b/test/shared/version.test.ts
@@ -1,0 +1,248 @@
+import * as assert from 'assert';
+import { Version } from '../../src/shared/version';
+
+export default () => {
+    suite('Version', () => {
+        suite('numbered parts', () => {
+            test('should get the set parts correctly', () => {
+                const v = new Version(1,2,3);
+
+                assert.strictEqual(v.getPart(0), 1);
+                assert.strictEqual(v.getPart(1), 2);
+                assert.strictEqual(v.getPart(2), 3);    
+            });
+            test('should have all not-set parts set to zero', () => {
+                const v = new Version(1);
+
+                assert.strictEqual(v.getPart(1), 0);
+                assert.strictEqual(v.getPart(2), 0);    
+                assert.strictEqual(v.getPart(3), 0);    
+                assert.strictEqual(v.getPart(4), 0);    
+            });
+        });
+        
+        suite('named parts', () => {
+            test('should have the major version set correctly', () => {
+                const v = new Version(8,14,2);
+
+                assert.strictEqual(v.major, 8);
+            });
+            test('should have the minor version set correctly', () => {
+                const v = new Version(8,14,2);
+
+                assert.strictEqual(v.minor, 14);    
+            });
+            test('should have the patch version set correctly', () => {
+                const v = new Version(8,14,2);
+
+                assert.strictEqual(v.patch, 2);    
+            });
+        });
+        
+        suite('parsing', () => {
+            test('should throw on empty text', () => {                
+                assert.throws(() => Version.parse(""));
+            });
+            test('should throw on non version', () => {
+                assert.throws(() => Version.parse("ThisIsNoVersion"));
+            });
+            test('should throw on non-number versions postfix', () => {
+                assert.throws(() => Version.parse("1.2.3xx"));
+            });
+            test('should throw on non-number versions prefix', () => {
+                assert.throws(() => Version.parse("1.2.xx3"));
+            });
+            test('should parse a single number', () => {
+                const v = Version.parse("2");
+
+                assert.strictEqual(v.major, 2);
+            });
+            test('should parse a major.minor version', () => {
+                const v = Version.parse("3.5");
+
+                assert.strictEqual(v.major, 3);
+                assert.strictEqual(v.minor, 5);
+            });
+            test('should parse a major.minor.patch version', () => {
+                const v = Version.parse("7.103.54778");
+
+                assert.strictEqual(v.major, 7);
+                assert.strictEqual(v.minor, 103);
+                assert.strictEqual(v.patch, 54778);
+            });
+            test('should parse a suffixed version', () => {
+                const verText = "0.55.34-beta2";
+                const v = Version.parse(verText);
+
+                assert.strictEqual(v.getPart(0), 0);
+                assert.strictEqual(v.getPart(1), 55);
+                assert.strictEqual(v.getPart(2), 34);
+                assert.strictEqual(v.getPart(3), 2);
+                assert.strictEqual(v.toString(), verText);
+            });
+        });
+
+        suite('comparing', () => {
+            test('should be equal on the same version-object', () => {
+                const v = new Version(1,2,3);
+
+                const actual = v.equalTo(v);
+
+                assert.strictEqual(actual, true);
+            });
+
+            test('should not be equal on null', () => {
+                const v = new Version(1,2,3);
+
+                const actual = v.equalTo(null as unknown as Version);
+
+                assert.strictEqual(actual, false);
+            });
+
+            [{
+                left: new Version(1,2,3),
+                right: new Version(1,2,3),
+                equal: true, 
+            }, {
+                left: new Version(1),
+                right: new Version(1,0,0),
+                equal: true, 
+            }, {
+                left: new Version(1,0,0,0),
+                right: new Version(1),
+                equal: true, 
+            }, {
+                left: new Version(1,2,3),
+                right: new Version(2),
+                equal: false, 
+            }, {
+                left: new Version(1,2,3),
+                right: new Version(1,2,4),
+                equal: false, 
+            }, {
+                left: Version.parse("1.0.0-alpha1"),
+                right: Version.parse("1.0.0-beta1"),
+                equal: true, 
+            }].forEach(x => {
+                test(`v${x.left.toString()} should be ${x.equal ? "equal": "not equal"} to v${x.right.toString()}`, () =>{
+                    const actual = x.left.equalTo(x.right);
+                    assert.strictEqual(actual, x.equal);
+                });
+            });
+
+            [{
+                left: new Version(1,2,3),
+                right: new Version(1,2,3),
+                orEqual: true,
+                greaterThan: true, 
+            }, {
+                left: new Version(1),
+                right: new Version(1,0,0),
+                orEqual: true,
+                greaterThan: true, 
+            }, {
+                left: new Version(1,0,0,0),
+                right: new Version(1),
+                orEqual: true,
+                greaterThan: true, 
+            }, {
+                left: new Version(1,2,3),
+                right: new Version(1,2,3),
+                orEqual: false,
+                greaterThan: false, 
+            }, {
+                left: new Version(1),
+                right: new Version(1,0,0),
+                orEqual: false,
+                greaterThan: false, 
+            }, {
+                left: new Version(1,0,0,0),
+                right: new Version(1),
+                orEqual: false,
+                greaterThan: false, 
+            }, {
+                left: new Version(1,2,3),
+                right: new Version(2),
+                orEqual: false,
+                greaterThan: false, 
+            }, {
+                left: new Version(1,2,3),
+                right: new Version(1,2,4),
+                orEqual: false,
+                greaterThan: false, 
+            }, {
+                left: new Version(1,2,3),
+                right: Version.parse("1.2.3-rc1"),
+                orEqual: true,
+                greaterThan: false, 
+            }].forEach(x => {
+                test(`v${x.left.toString()} should be ${x.greaterThan ? "": "not "}greater ${x.orEqual ? "or equal " : "" }than v${x.right.toString()}`, () =>{
+                    const actual = x.left.greaterThan(x.right, x.orEqual);
+                    assert.strictEqual(actual, x.greaterThan);
+                });
+            });
+
+            [{
+                left: new Version(1,2,3),
+                right: new Version(1,2,3),
+                orEqual: true,
+                lessThan: true, 
+            }, {
+                left: new Version(1),
+                right: new Version(1,0,0),
+                orEqual: true,
+                lessThan: true, 
+            }, {
+                left: new Version(1,0,0,0),
+                right: new Version(1),
+                orEqual: true,
+                lessThan: true, 
+            }, {
+                left: new Version(1,2,3),
+                right: new Version(1,2,3),
+                orEqual: false,
+                lessThan: false, 
+            }, {
+                left: new Version(1),
+                right: new Version(1,0,0),
+                orEqual: false,
+                lessThan: false, 
+            }, {
+                left: new Version(1,0,0,0),
+                right: new Version(1),
+                orEqual: false,
+                lessThan: false, 
+            }, {
+                left: new Version(3,2,1),
+                right: new Version(2),
+                orEqual: false,
+                lessThan: false, 
+            }, {
+                left: new Version(1,2,6),
+                right: new Version(1,2,4),
+                orEqual: false,
+                lessThan: false, 
+            }, {
+                left: new Version(1,2,3),
+                right: Version.parse("1.2.3-rc1"),
+                orEqual: false,
+                lessThan: true, 
+            }].forEach(x => {
+                test(`v${x.left.toString()} should be ${x.lessThan ? "": "not "}less ${x.orEqual ? "or equal " : "" }than v${x.right.toString()}`, () =>{
+                    const actual = x.left.lessThan(x.right, x.orEqual);
+                    assert.strictEqual(actual, x.lessThan);
+                });
+            });
+
+            // now the special cases
+            test('v0.38.5 should be less than v1.0.0-rc0001', () => {
+                const left = Version.parse("0.38.5");
+                const right = Version.parse("1.0.0-rc0001");
+
+                const actual = left.lessThan(right);
+
+                assert.strictEqual(actual, true);
+            });
+        });
+    });
+}


### PR DESCRIPTION
Checking for installed version of Cake.Tool, as well as
installing and updating  is now centralized and not longer
done in two places.
Additionally a check for a newer version of the Cake.Tool
was implemented.
To not ask for an update *every* time the version is checked,
a "Do not update to this version"-Function was implemented.

fixes #460 