### PR TITLE
(GH-470) Add check for which debugger to install

### DIFF
--- a/src/cakeMain.ts
+++ b/src/cakeMain.ts
@@ -74,7 +74,7 @@ export function activate(context: vscode.ExtensionContext): void {
     // Register the interactive install command.
     context.subscriptions.push(
         vscode.commands.registerCommand('cake.install', async () => {
-            installCakeToWorkspaceCommand();
+            installCakeToWorkspaceCommand(context);
         })
     );
     // Register the interactive install command.

--- a/src/cakeMain.ts
+++ b/src/cakeMain.ts
@@ -263,7 +263,7 @@ function _registerSymbolProvider(
             {
                 language: 'csharp',
                 scheme: 'file'
-            }, 
+            },
             documentSymbolProvider
         )
     );

--- a/src/codeLens/shared.ts
+++ b/src/codeLens/shared.ts
@@ -1,5 +1,5 @@
 import { ExtensionContext, workspace } from 'vscode';
-import { CakeTool } from '../debug/cakeTool';
+import { CakeTool } from '../shared/cakeTool';
 import { IExtensionSettings } from '../extensionSettings';
 import { logError, logInfo } from '../shared/log';
 

--- a/src/debug/cakeDebugCommand.ts
+++ b/src/debug/cakeDebugCommand.ts
@@ -25,12 +25,12 @@ export async function installCakeDebugCommand(context: ExtensionContext, hideWar
         advice: isCakeTool ?
             'Cake Debug Dependencies correctly installed globally.' :
             'Cake Debug Dependencies correctly downloaded.',
-        warning: isCakeTool ? 
+        warning: isCakeTool ?
             'Cake.Tool is already installed globally' :
             'Cake.CoreCLR package has already been installed.',
-        error: isCakeTool ? 
-            'Error installing Cake Debug Dependencies' : 
-            'Error downloading Cake Debug Dependencies'
+        error: isCakeTool ?
+            'Error installing Cake Debug Dependencies.' :
+            'Error downloading Cake Debug Dependencies.'
     }
 
     if (result.installed) {

--- a/src/debug/cakeDebugCommand.ts
+++ b/src/debug/cakeDebugCommand.ts
@@ -1,7 +1,8 @@
 import { ExtensionContext, window, workspace } from 'vscode';
 import * as fs from 'fs';
-import { CakeDebug } from './cakeDebug';
-import { CakeTool } from './cakeTool';
+import { enums, interfaces } from '../shared';
+import { CakeDebug } from '../shared/cakeDebug';
+import { CakeTool } from '../shared/cakeTool';
 
 export async function installCakeDebugCommand(context: ExtensionContext, hideWarning?: boolean): Promise<boolean> {
     // Check if there is an open folder in workspace
@@ -11,15 +12,15 @@ export async function installCakeDebugCommand(context: ExtensionContext, hideWar
     }
 
     const selection = await window.showQuickPick([
-        'Cake.Tool',
-        'Cake.CoreCLR'
+        enums.DebugType.NetTool,
+        enums.DebugType.NetCore
     ]);
 
     if(!selection){
         return false;
     }
 
-    const isCakeTool = selection === 'Cake.Tool';
+    const isCakeTool = selection as enums.DebugType === enums.DebugType.NetTool;
     const result = await (isCakeTool ? installCakeTool(context)  : installCakeDebug());
     const messages = {
         advice: isCakeTool ?
@@ -47,12 +48,7 @@ export async function installCakeDebugCommand(context: ExtensionContext, hideWar
     return true;
 }
 
-interface IInstallResult {
-    installed: boolean;
-    advice: boolean;
-}
-
-export async function installCakeDebug(): Promise<IInstallResult> {
+export async function installCakeDebug(): Promise<interfaces.IInstallResult> {
     let debug = new CakeDebug();
 
     var targetPath = debug.getTargetPath();
@@ -64,7 +60,7 @@ export async function installCakeDebug(): Promise<IInstallResult> {
     return { installed: result, advice: true };
 }
 
-async function installCakeTool(context: ExtensionContext): Promise<IInstallResult> {
+export async function installCakeTool(context: ExtensionContext): Promise<interfaces.IInstallResult> {
     const tool = new CakeTool(context);
     const installationModified = await tool.ensureInstalled();
     return { installed: true, advice: installationModified };

--- a/src/install/actions/installCake.ts
+++ b/src/install/actions/installCake.ts
@@ -1,11 +1,11 @@
 import * as vscode from 'vscode';
-import { logger } from '../../shared';
+import { enums, logger } from '../../shared';
 import InstallOptions from '../installOptions';
 import { ERROR_INVALID_SETTINGS, ERROR_NO_WORKSPACE } from '../../constants';
 import { installBootstrappers } from './bootstrapper';
 import { installBuildFile } from '../../buildFile/cakeBuildFileCommand';
 import { installCakeConfiguration } from '../../configuration/cakeConfigurationCommand';
-import { installCakeDebug } from '../../debug/cakeDebugCommand';
+import { installCakeDebug, installCakeTool } from '../../debug/cakeDebugCommand';
 
 export function installCake(
     installOpts: InstallOptions | undefined
@@ -74,18 +74,30 @@ export function installCake(
             Promise.all(results)
                 .then(
                     _ => {
-                        // TODO: Is a selection CoreCLR/global tool needed?
                         if (installOpts.installDebug) {
-                            installCakeDebug().then(v => {
-                                logResult(
-                                    v.installed,
-                                    'Debug dependencies successfully installed.',
-                                    'Error encountered while install debugging dependencies.'
-                                );
-                                vscode.window.showInformationMessage(
-                                    "Add a new 'Cake' debug configuration to get started debugging your script."
-                                );
-                            })
+                            if(installOpts.debuggerType === enums.DebugType.NetTool) {
+                                installCakeTool(installOpts.context).then(v => {
+                                    logResult(
+                                        v.installed,
+                                        'Cake Debug Dependencies correctly installed globally.',
+                                        'Error installing Cake Debug Dependencies.'
+                                    );
+                                })
+                            }
+
+                            if(installOpts.debuggerType === enums.DebugType.NetCore) {
+                                installCakeDebug().then(v => {
+                                    logResult(
+                                        v.installed,
+                                        'Cake Debug Dependencies correctly downloaded.',
+                                        'Error downloading Cake Debug Dependencies.'
+                                    );
+                                })
+                            }
+
+                            vscode.window.showInformationMessage(
+                                "Add a new 'Cake' debug configuration to get started debugging your script."
+                            );
                         }
 
                         // Clear the status bar, and display final notification

--- a/src/install/cakeInstallCommand.ts
+++ b/src/install/cakeInstallCommand.ts
@@ -1,24 +1,24 @@
-import { window } from 'vscode';
+import { window, ExtensionContext } from 'vscode';
 import {
     showScriptNameBox,
     showBootstrapperOption,
-    handleScriptNameResponse,
     showConfigOption,
     showBootstrapperTypeOption,
     showDebugOption,
+    showDebugTypeOption,
     installCake
 } from './actions'
 
 import { CANCEL } from '../constants'
 import { logger } from "../shared";
 
-export function installCakeToWorkspaceCommand() {
-    showScriptNameBox()
-        .then(handleScriptNameResponse)
+export function installCakeToWorkspaceCommand(context: ExtensionContext) {
+    showScriptNameBox(context)
         .then(showBootstrapperOption)
         .then(showBootstrapperTypeOption)
         .then(showConfigOption)
         .then(showDebugOption)
+        .then(showDebugTypeOption)
         .then(installCake)
         .then(({message, fileName}) => {
             window.showInformationMessage(message);

--- a/src/install/installOptions.ts
+++ b/src/install/installOptions.ts
@@ -1,9 +1,11 @@
+import { ExtensionContext } from 'vscode';
 import { enums } from '../shared';
 
 export default class InstallOptions {
-    constructor(public scriptName: string) { }
+    constructor(public scriptName: string, public context: ExtensionContext) { }
     installBootstrappers!: boolean;
     bootstrapperType!: enums.RunnerType;
     installConfig!: boolean;
     installDebug!: boolean;
+    debuggerType!: enums.DebugType;
 }

--- a/src/shared/cakeDebug.ts
+++ b/src/shared/cakeDebug.ts
@@ -1,10 +1,10 @@
-import { readCakeConfigFile } from '../shared/utils/readConfigFile';
+import { readCakeConfigFile } from './utils/readConfigFile';
 var request = require('request');
 var AdmZip = require('adm-zip');
 import { window, workspace } from 'vscode';
 import * as path from 'path';
 import * as fs from 'fs';
-import * as utils from './../shared/utils';
+import * as utils from './utils';
 import {
     DEFAULT_RESPONSE_TIMEOUT,
     CAKE_CORECLR_PACKAGE_URL

--- a/src/shared/cakeTool.ts
+++ b/src/shared/cakeTool.ts
@@ -1,6 +1,6 @@
 import { ChildProcessWithoutNullStreams, spawn } from 'child_process';
 import { window, Memento, ExtensionContext } from 'vscode';
-import { Version } from '../shared/version';
+import { Version } from './version';
 
 export class CakeTool {
 
@@ -50,11 +50,11 @@ export class CakeTool {
         const ver = await this.getCakeVersionFromProc(proc);
         return ver;
     }
-    
+
     public install(): Thenable<boolean> {
         return new Promise((resolve, reject) => {
             const proc = spawn('dotnet', ['tool', 'install', 'Cake.Tool', '--global']);
-            
+
             proc.on('error', (error) => {
                 reject(error);
             });
@@ -68,7 +68,7 @@ export class CakeTool {
     public update(): Thenable<boolean> {
         return new Promise((resolve, reject) => {
             const proc = spawn('dotnet', ['tool', 'update', 'Cake.Tool', '--global']);
-            
+
             proc.on('error', (error) => {
                 reject(error);
             });
@@ -91,18 +91,18 @@ export class CakeTool {
             await this.install();
             return true;
         }
-    
+
         const availableVersion = await this.getAvailableVersion();
         if(availableVersion === null) {
             // cake.tool is installed, but we were unable to detect if it's the newest version
             // probably ok..
             return false;
         }
-    
+
         if(installedVersion.greaterThan(availableVersion, true)) {
             return false;
         }
-    
+
         // ask for updates or skip
         if(await this.shouldSkipVersionUpdate(availableVersion)) {
             return false;
@@ -117,7 +117,7 @@ export class CakeTool {
         const selection = await window.showQuickPick([answers.yes, answers.no, answers.notThisVersion], {
             placeHolder: `Cake.Tool version ${availableVersion.toString()} is available. Update now?`
         });
-    
+
         if(selection !== answers.yes) {
             if(selection === answers.notThisVersion){
                 await this.storeVersionToSkip(availableVersion);
@@ -125,7 +125,7 @@ export class CakeTool {
 
             return false;
         }
-    
+
         await this.update();
         return true;
     }

--- a/src/shared/enums.ts
+++ b/src/shared/enums.ts
@@ -3,3 +3,8 @@ export enum RunnerType {
   NetFramwork = "NETFRAMEWORK",
   NetCore = "NETCORE"
 }
+
+export enum DebugType {
+  NetTool = "NETTOOL",
+  NetCore = "NETCORE"
+}

--- a/src/shared/index.ts
+++ b/src/shared/index.ts
@@ -2,10 +2,12 @@ import * as logger from './log';
 import * as utils from './utils';
 import * as messages from './messages';
 import * as enums from './enums';
+import * as interfaces from './interfaces';
 
 export {
     logger,
     messages,
     utils,
-    enums
+    enums,
+    interfaces
 };

--- a/src/shared/interfaces.ts
+++ b/src/shared/interfaces.ts
@@ -1,0 +1,4 @@
+export interface IInstallResult {
+  installed: boolean;
+  advice: boolean;
+}

--- a/src/shared/messages.ts
+++ b/src/shared/messages.ts
@@ -1,4 +1,5 @@
 export const PROMPT_SCRIPT_NAME = 'Enter the name for your new build script';
+export const CONFIRM_DEBUG_TYPE_OPTION = 'What type of debugging support would you like to install?'
 export const CONFIRM_BOOTSTRAPPER_TYPE = 'What Cake Runner would you like to install Bootstrappers for?';
 export const CONFIRM_INSTALL_BOOTSTRAPPERS = 'Do you want to install the bootstrappers?';
 export const CONFIRM_INSTALL_CONFIG = 'Do you want to install a cake.config file?';


### PR DESCRIPTION
When installing Cake to the current workspace, if installed debug
support, check which type of debugger they would like to install.

Refactored a little bit of code to get things to work, I suspect that
there are further refactorings that could be done.

Fixes #470