### PR TITLE
GH-476: Fix incorrect link generated for the cake-vscode extension

### DIFF
--- a/recipe.cake
+++ b/recipe.cake
@@ -19,7 +19,8 @@ BuildParameters.SetParameters(context: Context,
                             appVeyorAccountName: "cakebuild",
                             shouldRunGitVersion: true,
                             vsceVersionNumber:"1.78.0",
-                            typeScriptVersionNumber: "4.1.2");
+                            typeScriptVersionNumber: "4.1.2",
+                            marketPlacePublisher: "cake-build");
 
 BuildParameters.PrintParameters(Context);
 


### PR DESCRIPTION
[`marketPlacePublisher` defaults to `gep13` in Cake.VsCode.Recipe](https://github.com/cake-contrib/Cake.VsCode.Recipe/blob/86002f3d6cc974b2eb7d66b47cf158bf5d588e50/Cake.VsCode.Recipe/Content/parameters.cake#L310) which is why the Twitter link was incorrect.

---

Resolves #476 