### PR TITLE
(build) Update to latest TypeScript

### DIFF
--- a/recipe.cake
+++ b/recipe.cake
@@ -19,7 +19,7 @@ BuildParameters.SetParameters(context: Context,
                             appVeyorAccountName: "cakebuild",
                             shouldRunGitVersion: true,
                             vsceVersionNumber:"1.78.0",
-                            typeScriptVersionNumber: "4.5.2",
+                            typeScriptVersionNumber: "4.5.3",
                             marketPlacePublisher: "cake-build");
 
 BuildParameters.PrintParameters(Context);


### PR DESCRIPTION
This was updated automatically as a result of a dependabot PR, so make
sure to use same version for Cake build.