### PR TITLE
Use dll instead of exe for Cake Bakery

### DIFF
--- a/src/bakery/cakeBakery.ts
+++ b/src/bakery/cakeBakery.ts
@@ -18,7 +18,7 @@ export class CakeBakery {
     public getTargetPath(): string {
         return path.join(
             this.extensionPath,
-            'Cake.Bakery/tools/Cake.Bakery.exe'
+            'Cake.Bakery/tools/Cake.Bakery.dll'
         );
     }
 


### PR DESCRIPTION
This will ensure the default also works on Linux and Mac.

Fixes #719 