### PR TITLE
(#730) added a new script task `ensureCi`

### DIFF
--- a/package.json
+++ b/package.json
@@ -619,9 +619,10 @@
   "scripts": {
     "vscode:prepublish": "npm run compile",
     "compile": "tsc -p ./",
-    "watch": "tsc -watch -p ./",
+    "watch": "npm run ensureCi && tsc -watch -p ./",
     "test": "npm run compile && node ./out/test/runTest.js",
-    "depcheck": "depcheck"
+    "depcheck": "depcheck",
+    "ensureCi": "node -e \"const fs=require('fs'); if (fs.existsSync('./node_modules/')) { process.exit(123); }\" && npm ci"
   },
   "dependencies": {
     "adm-zip": "^0.5.9",


### PR DESCRIPTION
Which calls "npm ci", if `node_modules` does not exist. By calling this before the "watch" task,
the workflow of clone, start VSCode, hit F5 will "simply work".

fixes #730 