### PR TITLE
(#733) use existing properties inside omnisharp.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -622,7 +622,7 @@
     "watch": "npm run ensureCi && tsc -watch -p ./",
     "test": "npm run compile && node ./out/test/runTest.js",
     "depcheck": "depcheck",
-    "ensureCi": "node -e \"const fs=require('fs'); if (fs.existsSync('./node_modules/')) { process.exit(123); }\" && npm ci"
+    "ensureCi": "(node -e \"const fs=require('fs'); if (fs.existsSync('./node_modules/')) { process.exit(123); }\" && npm ci) & echo 'ensured.'"
   },
   "dependencies": {
     "adm-zip": "^0.5.9",

--- a/src/bakery/cakeBakeryCommand.ts
+++ b/src/bakery/cakeBakeryCommand.ts
@@ -5,16 +5,20 @@ import { logger } from '../shared'
 
 export async function updateCakeBakeryCommand(extensionPath: string) {
     // Install Cake Bakery
-    var result = await forceInstallBakery(extensionPath);
-    if (result) {
-        commands.executeCommand('o.restart');
-        window.showInformationMessage(
-            'Intellisense support (Cake.Bakery) for Cake files was installed.'
-        );
-    } else {
-        window.showErrorMessage(
-            'Error downloading intellisense support (Cake.Bakery) for Cake files.'
-        );
+    try {
+        var result = await forceInstallBakery(extensionPath);
+        if (result) {
+            commands.executeCommand('o.restart');
+            window.showInformationMessage(
+                'Intellisense support (Cake.Bakery) for Cake files was installed.'
+            );
+        } else {
+            window.showErrorMessage(
+                'Error downloading intellisense support (Cake.Bakery) for Cake files.'
+            );
+        }
+    } catch (e: unknown) {
+        logger.logError("Intellisense support (Cake.Bakery) for Cake files NOT installed!\r\n> "+e, false)
     }
 }
 


### PR DESCRIPTION
Instead of enforcing properties "cake" and "bakeryPath"
 case-sensitive.
Closes #733